### PR TITLE
chore: create OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,12 @@
+reviewers:
+- ruibaby
+- guqing
+- JohnNiang
+- lan-yonghui
+- wangzhen-fit2cloud
+- QuentinHsu
+
+approvers:
+- ruibaby
+- guqing
+- JohnNiang


### PR DESCRIPTION
The OWNERS file is for prow only. See https://www.kubernetes.dev/docs/guide/owners/ for more.

Signed-off-by: Ryan Wang <i@ryanc.cc>