### PR TITLE
docs: remove tencent developer labs sidebar link

### DIFF
--- a/i18n/zh-Hans/code.json
+++ b/i18n/zh-Hans/code.json
@@ -23,18 +23,6 @@
     "message": "关闭",
     "description": "The ARIA label for close button of announcement bar"
   },
-  "theme.blog.paginator.navAriaLabel": {
-    "message": "博文列表分页导航",
-    "description": "The ARIA label for the blog pagination"
-  },
-  "theme.blog.paginator.newerEntries": {
-    "message": "较新的博文",
-    "description": "The label used to navigate to the newer blog posts page (previous page)"
-  },
-  "theme.blog.paginator.olderEntries": {
-    "message": "较旧的博文",
-    "description": "The label used to navigate to the older blog posts page (next page)"
-  },
   "theme.BackToTopButton.buttonAriaLabel": {
     "message": "回到顶部",
     "description": "The ARIA label for the back to top button"
@@ -46,6 +34,18 @@
   "theme.blog.archive.description": {
     "message": "历史博文",
     "description": "The page & hero description of the blog archive page"
+  },
+  "theme.blog.paginator.navAriaLabel": {
+    "message": "博文列表分页导航",
+    "description": "The ARIA label for the blog pagination"
+  },
+  "theme.blog.paginator.newerEntries": {
+    "message": "较新的博文",
+    "description": "The label used to navigate to the newer blog posts page (previous page)"
+  },
+  "theme.blog.paginator.olderEntries": {
+    "message": "较旧的博文",
+    "description": "The label used to navigate to the older blog posts page (next page)"
   },
   "theme.blog.post.readingTime.plurals": {
     "message": "{readingTime} 分钟阅读",
@@ -87,18 +87,6 @@
     "message": "查看所有标签",
     "description": "The label of the link targeting the tag list page"
   },
-  "theme.CodeBlock.copyButtonAriaLabel": {
-    "message": "复制代码到剪贴板",
-    "description": "The ARIA label for copy code blocks button"
-  },
-  "theme.CodeBlock.copied": {
-    "message": "复制成功",
-    "description": "The copied button label on code blocks"
-  },
-  "theme.CodeBlock.copy": {
-    "message": "复制",
-    "description": "The copy button label on code blocks"
-  },
   "theme.colorToggle.ariaLabel": {
     "message": "切换浅色/暗黑模式（当前为{mode}）",
     "description": "The ARIA label for the navbar color mode toggle"
@@ -115,14 +103,6 @@
     "message": "{count} 个项目",
     "description": "The default description for a category card in the generated index about how many items this category includes"
   },
-  "theme.docs.sidebar.expandButtonTitle": {
-    "message": "展开侧边栏",
-    "description": "The ARIA label and title attribute for expand button of doc sidebar"
-  },
-  "theme.docs.sidebar.expandButtonAriaLabel": {
-    "message": "展开侧边栏",
-    "description": "The ARIA label and title attribute for expand button of doc sidebar"
-  },
   "theme.docs.paginator.navAriaLabel": {
     "message": "文档分页导航",
     "description": "The ARIA label for the docs pagination"
@@ -135,13 +115,13 @@
     "message": "下一页",
     "description": "The label used to navigate to the next doc"
   },
-  "theme.docs.sidebar.collapseButtonTitle": {
-    "message": "收起侧边栏",
-    "description": "The title attribute for collapse button of doc sidebar"
+  "theme.docs.sidebar.expandButtonTitle": {
+    "message": "展开侧边栏",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
   },
-  "theme.docs.sidebar.collapseButtonAriaLabel": {
-    "message": "收起侧边栏",
-    "description": "The title attribute for collapse button of doc sidebar"
+  "theme.docs.sidebar.expandButtonAriaLabel": {
+    "message": "展开侧边栏",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
   },
   "theme.DocSidebarItem.toggleCollapsedCategoryAriaLabel": {
     "message": "打开/收起侧边栏菜单「{label}」",
@@ -152,8 +132,11 @@
     "description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
   },
   "theme.docs.tagDocListPageTitle": {
-    "message": "{nDocsTagged} 篇带有标签「{tagName}」",
+    "message": "{nDocsTagged}「{tagName}」",
     "description": "The title of the page for a docs tag"
+  },
+  "theme.docs.versionBadge.label": {
+    "message": "版本：{versionLabel}"
   },
   "theme.docs.versions.unreleasedVersionLabel": {
     "message": "此为 {siteTitle} {versionLabel} 版尚未发行的文档。",
@@ -175,9 +158,6 @@
     "message": "编辑此页",
     "description": "The link label to edit the current page"
   },
-  "theme.docs.versionBadge.label": {
-    "message": "版本：{versionLabel}"
-  },
   "theme.common.headingLinkTitle": {
     "message": "标题的直接链接",
     "description": "Title for link to heading"
@@ -193,10 +173,6 @@
   "theme.lastUpdated.lastUpdatedAtBy": {
     "message": "最后{byUser}{atDate}更新",
     "description": "The sentence used to display when a page has been last updated, and by who"
-  },
-  "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
-    "message": "← 回到主菜单",
-    "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
   },
   "theme.navbar.mobileVersionsDropdown.label": {
     "message": "选择版本",
@@ -214,9 +190,40 @@
     "message": "标签：",
     "description": "The label alongside a tag list"
   },
+  "theme.CodeBlock.copied": {
+    "message": "复制成功",
+    "description": "The copied button label on code blocks"
+  },
+  "theme.CodeBlock.copyButtonAriaLabel": {
+    "message": "复制代码到剪贴板",
+    "description": "The ARIA label for copy code blocks button"
+  },
+  "theme.CodeBlock.copy": {
+    "message": "复制",
+    "description": "The copy button label on code blocks"
+  },
   "theme.navbar.mobileLanguageDropdown.label": {
     "message": "选择语言",
     "description": "The label for the mobile language switcher dropdown"
+  },
+  "theme.docs.sidebar.collapseButtonTitle": {
+    "message": "收起侧边栏",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.collapseButtonAriaLabel": {
+    "message": "收起侧边栏",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
+    "message": "← 回到主菜单",
+    "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
+  },
+  "theme.SearchBar.seeAll": {
+    "message": "查看全部 {count} 个结果"
+  },
+  "theme.SearchBar.label": {
+    "message": "搜索",
+    "description": "The ARIA label and placeholder for search button"
   },
   "theme.SearchPage.documentsFound.plurals": {
     "message": "找到 {count} 份文件",
@@ -249,13 +256,6 @@
   "theme.SearchPage.fetchingNewResults": {
     "message": "正在获取新的搜索结果...",
     "description": "The paragraph for fetching new search results"
-  },
-  "theme.SearchBar.seeAll": {
-    "message": "查看全部 {count} 个结果"
-  },
-  "theme.SearchBar.label": {
-    "message": "搜索",
-    "description": "The ARIA label and placeholder for search button"
   },
   "theme.tags.tagsPageTitle": {
     "message": "标签",

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current.json
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current.json
@@ -35,10 +35,6 @@
     "message": "参与贡献",
     "description": "The label for category 参与贡献 in sidebar tutorialSidebar"
   },
-  "sidebar.tutorialSidebar.link.腾讯云开发者实验室": {
-    "message": "腾讯云开发者实验室",
-    "description": "The label for link 腾讯云开发者实验室 in sidebar tutorialSidebar, linking to https://cloud.tencent.com/developer/labs/lab/10523"
-  },
   "sidebar.tutorialSidebar.link.REST API": {
     "message": "REST API",
     "description": "The label for link REST API in sidebar tutorialSidebar, linking to https://api.halo.run"

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/version-1.5.1.json
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/version-1.5.1.json
@@ -35,10 +35,6 @@
     "message": "参与贡献",
     "description": "The label for category 参与贡献 in sidebar tutorialSidebar"
   },
-  "sidebar.tutorialSidebar.link.腾讯云开发者实验室": {
-    "message": "腾讯云开发者实验室",
-    "description": "The label for link 腾讯云开发者实验室 in sidebar tutorialSidebar, linking to https://cloud.tencent.com/developer/labs/lab/10523"
-  },
   "sidebar.tutorialSidebar.link.REST API": {
     "message": "REST API",
     "description": "The label for link REST API in sidebar tutorialSidebar, linking to https://api.halo.run"

--- a/sidebars.js
+++ b/sidebars.js
@@ -35,12 +35,7 @@ module.exports = {
                 "getting-started/install/other/oneinstack",
                 "getting-started/install/other/tencent-cloudbase",
                 "getting-started/install/other/docker-mysql",
-                "getting-started/install/other/docker-compose",
-                {
-                  type: "link",
-                  label: "腾讯云开发者实验室",
-                  href: "https://cloud.tencent.com/developer/labs/lab/10523",
-                },
+                "getting-started/install/other/docker-compose"
               ],
             },
             "getting-started/install/third-party",

--- a/versioned_sidebars/version-1.5.1-sidebars.json
+++ b/versioned_sidebars/version-1.5.1-sidebars.json
@@ -20,12 +20,7 @@
                 "getting-started/install/other/bt-panel",
                 "getting-started/install/other/oneinstack",
                 "getting-started/install/other/tencent-cloudbase",
-                "getting-started/install/other/docker-mysql",
-                {
-                  "type": "link",
-                  "label": "腾讯云开发者实验室",
-                  "href": "https://cloud.tencent.com/developer/labs/lab/10523"
-                }
+                "getting-started/install/other/docker-mysql"
               ]
             },
             "getting-started/install/third-party"


### PR DESCRIPTION
移除腾讯云开发者实验室的链接。目前 https://cloud.tencent.com/lab/labslist 已经改版，并且不知道为何 Halo 的实验教程已经被删除，所以在文档移除这个链接。

Signed-off-by: Ryan Wang <i@ryanc.cc>