### PR TITLE
Change mirror frontend URL from https://dl.halo.run to https://download.halo.run

### DIFF
--- a/docs/getting-started/downloads.md
+++ b/docs/getting-started/downloads.md
@@ -14,7 +14,7 @@ description: 目前所有与 Halo 相关的下载地址
 
 ## 官方镜像源
 
-- [https://dl.halo.run](https://dl.halo.run)
+- [https://download.halo.run](https://download.halo.run)
 
 此镜像源由 [Nova Kwok](https://nova.moe/) 提供并维护。
 

--- a/versioned_docs/version-1.4/getting-started/downloads.md
+++ b/versioned_docs/version-1.4/getting-started/downloads.md
@@ -14,7 +14,7 @@ description: 目前所有与 Halo 相关的下载地址
 
 ## 官方镜像源
 
-- [https://dl.halo.run](https://dl.halo.run)
+- [https://download.halo.run](https://download.halo.run)
 
 此镜像源由 [Nova Kwok](https://nova.moe/) 提供并维护。
 

--- a/versioned_docs/version-1.5/getting-started/downloads.md
+++ b/versioned_docs/version-1.5/getting-started/downloads.md
@@ -14,7 +14,7 @@ description: 目前所有与 Halo 相关的下载地址
 
 ## 官方镜像源
 
-- [https://dl.halo.run](https://dl.halo.run)
+- [https://download.halo.run](https://download.halo.run)
 
 此镜像源由 [Nova Kwok](https://nova.moe/) 提供并维护。
 

--- a/versioned_docs/version-1.6/getting-started/downloads.md
+++ b/versioned_docs/version-1.6/getting-started/downloads.md
@@ -14,7 +14,7 @@ description: 目前所有与 Halo 相关的下载地址
 
 ## 官方镜像源
 
-- [https://dl.halo.run](https://dl.halo.run)
+- [https://download.halo.run](https://download.halo.run)
 
 此镜像源由 [Nova Kwok](https://nova.moe/) 提供并维护。
 


### PR DESCRIPTION
Change mirror site frontend website to new address, shouldn't affect old download link such as `https://dl.halo.run/release/halo-1.3.0.jar`

Related post: https://nova.moe/halo-mirror-serverless/
Related repo: https://github.com/halo-sigs/halo-dl-api

```release-note
None
```