### PR TITLE
docs: update docker-compose.md for PostgreSQL PGUSER env

### DIFF
--- a/docs/getting-started/install/docker-compose.md
+++ b/docs/getting-started/install/docker-compose.md
@@ -87,6 +87,7 @@ description: 使用 Docker Compose 部署
           - POSTGRES_PASSWORD=openpostgresql
           - POSTGRES_USER=halo
           - POSTGRES_DB=halo
+          - PGUSER=halo
 
     networks:
       halo_network:


### PR DESCRIPTION
add PGUSER to fix `FATAL: role "root" does not exist` warning.

```release-note
None
```