### PR TITLE
fix: wrong example of contributor finder api

### DIFF
--- a/versioned_docs/version-2.1/developer-guide/theme/finder-apis/contributor.md
+++ b/versioned_docs/version-2.1/developer-guide/theme/finder-apis/contributor.md
@@ -26,7 +26,7 @@ contributorFinder.getContributor(name)
 ### 示例
 
 ```html
-<div th:with="contributor = ${contributorFinder.getByName('contributor-foo')}">
+<div th:with="contributor = ${contributorFinder.getContributor('contributor-foo')}">
   <h1 th:text="${contributor.displayName}"></h1>
 </div>
 ```
@@ -52,7 +52,7 @@ List<[#Contributor](#contributor)>
 ### 示例
 
 ```html
-<div th:with="contributors = ${contributorFinder.getByNames(['contributor-foo, 'contributor-bar'])}">
+<div th:with="contributors = ${contributorFinder.getContributors(['contributor-foo, 'contributor-bar'])}">
   <span th:each="contributor : ${contributors}" th:text="${contributor.displayName}"></span>
 </div>
 ```


### PR DESCRIPTION
修复关于 Contributor 的 Finder API 示例错误的问题。

/kind documentation

Fixes #158 

```release-note
None
```