### PR TITLE
docs: add healthcheck for halo in compose

### DIFF
--- a/docs/getting-started/install/docker-compose.md
+++ b/docs/getting-started/install/docker-compose.md
@@ -66,6 +66,12 @@ import DockerArgs from "./slots/docker-args.md"
           - ./:/root/.halo2
         ports:
           - "8090:8090"
+        healthcheck:
+          test: ["CMD", "curl", "-f", "http://localhost:8090/actuator/globalinfo"]
+          interval: 30s
+          timeout: 5s
+          retries: 5
+          start_period: 30s          
         command:
           - --spring.r2dbc.url=r2dbc:pool:postgresql://halodb/halo
           - --spring.r2dbc.username=halo
@@ -122,6 +128,12 @@ import DockerArgs from "./slots/docker-args.md"
           - ./:/root/.halo2
         ports:
           - "8090:8090"
+        healthcheck:
+          test: ["CMD", "curl", "-f", "http://localhost:8090/actuator/globalinfo"]
+          interval: 30s
+          timeout: 5s
+          retries: 5
+          start_period: 30s
         command:
           - --spring.r2dbc.url=r2dbc:pool:mysql://halodb:3306/halo
           - --spring.r2dbc.username=root
@@ -179,6 +191,12 @@ import DockerArgs from "./slots/docker-args.md"
           - ./:/root/.halo2
         ports:
           - "8090:8090"
+        healthcheck:
+          test: ["CMD", "curl", "-f", "http://localhost:8090/actuator/globalinfo"]
+          interval: 30s
+          timeout: 5s
+          retries: 5
+          start_period: 30s          
         command:
           # 外部访问地址，请根据实际需要修改
           - --halo.external-url=http://localhost:8090/

--- a/docs/getting-started/install/docker-compose.md
+++ b/docs/getting-started/install/docker-compose.md
@@ -67,7 +67,7 @@ import DockerArgs from "./slots/docker-args.md"
         ports:
           - "8090:8090"
         healthcheck:
-          test: ["CMD", "curl", "-f", "http://localhost:8090/actuator/globalinfo"]
+          test: ["CMD", "curl", "-f", "http://localhost:8090/actuator/health/readiness"]
           interval: 30s
           timeout: 5s
           retries: 5
@@ -129,7 +129,7 @@ import DockerArgs from "./slots/docker-args.md"
         ports:
           - "8090:8090"
         healthcheck:
-          test: ["CMD", "curl", "-f", "http://localhost:8090/actuator/globalinfo"]
+          test: ["CMD", "curl", "-f", "http://localhost:8090/actuator/health/readiness"]
           interval: 30s
           timeout: 5s
           retries: 5
@@ -192,7 +192,7 @@ import DockerArgs from "./slots/docker-args.md"
         ports:
           - "8090:8090"
         healthcheck:
-          test: ["CMD", "curl", "-f", "http://localhost:8090/actuator/globalinfo"]
+          test: ["CMD", "curl", "-f", "http://localhost:8090/actuator/health/readiness"]
           interval: 30s
           timeout: 5s
           retries: 5

--- a/versioned_docs/version-2.2/getting-started/install/docker-compose.md
+++ b/versioned_docs/version-2.2/getting-started/install/docker-compose.md
@@ -66,6 +66,12 @@ import DockerArgs from "./slots/docker-args.md"
           - ./:/root/.halo2
         ports:
           - "8090:8090"
+        healthcheck:
+          test: ["CMD", "curl", "-f", "http://localhost:8090/actuator/health/readiness"]
+          interval: 30s
+          timeout: 5s
+          retries: 5
+          start_period: 30s          
         command:
           - --spring.r2dbc.url=r2dbc:pool:postgresql://halodb/halo
           - --spring.r2dbc.username=halo
@@ -122,6 +128,12 @@ import DockerArgs from "./slots/docker-args.md"
           - ./:/root/.halo2
         ports:
           - "8090:8090"
+        healthcheck:
+          test: ["CMD", "curl", "-f", "http://localhost:8090/actuator/health/readiness"]
+          interval: 30s
+          timeout: 5s
+          retries: 5
+          start_period: 30s          
         command:
           - --spring.r2dbc.url=r2dbc:pool:mysql://halodb:3306/halo
           - --spring.r2dbc.username=root
@@ -179,6 +191,12 @@ import DockerArgs from "./slots/docker-args.md"
           - ./:/root/.halo2
         ports:
           - "8090:8090"
+        healthcheck:
+          test: ["CMD", "curl", "-f", "http://localhost:8090/actuator/health/readiness"]
+          interval: 30s
+          timeout: 5s
+          retries: 5
+          start_period: 30s          
         command:
           # 外部访问地址，请根据实际需要修改
           - --halo.external-url=http://localhost:8090/


### PR DESCRIPTION
在 Docker Compose 文件中，使用 `/actuator/health/readiness` 接口为 Halo 服务增加健康检查。


```release-note
docs: add healthcheck for halo in compose
```