### PR TITLE
docs:  add a tip for default admin username and password for development environment

### DIFF
--- a/docs/developer-guide/core/run.md
+++ b/docs/developer-guide/core/run.md
@@ -103,3 +103,16 @@ halo:
     ```
 
 5. 最终访问 `http://localhost:8090/console` 即可进入控制台。访问 `http://localhost:8090` 即可进入站点首页。
+
+:::info
+开发环境下，超级管理员的默认用户名为 `admin`，默认密码为 `admin`。可通过修改 `application-dev.yaml` 配置文件进行更改：
+
+```yaml
+halo:
+  security:
+    initializer:
+      super-admin-username: admin
+      super-admin-password: admin
+```
+
+:::

--- a/docs/developer-guide/core/run.md
+++ b/docs/developer-guide/core/run.md
@@ -105,7 +105,7 @@ halo:
 5. 最终访问 `http://localhost:8090/console` 即可进入控制台。访问 `http://localhost:8090` 即可进入站点首页。
 
 :::info
-开发环境下，超级管理员的默认用户名为 `admin`，默认密码为 `admin`。可通过修改 `application-dev.yaml` 配置文件进行更改：
+开发环境下，超级管理员的默认用户名为 `admin`，默认密码为 `admin`。也可通过修改 `application-dev.yaml` 配置文件进行更改：
 
 ```yaml
 halo:

--- a/versioned_docs/version-2.0/developer-guide/core/run.md
+++ b/versioned_docs/version-2.0/developer-guide/core/run.md
@@ -103,3 +103,16 @@ halo:
     ```
 
 5. 最终访问 `http://localhost:8090/console` 即可进入控制台。访问 `http://localhost:8090` 即可进入站点首页。
+
+:::info
+开发环境下，超级管理员的默认用户名为 `admin`，默认密码为 `admin`。可通过修改 `application-dev.yaml` 配置文件进行更改：
+
+```yaml
+halo:
+  security:
+    initializer:
+      super-admin-username: admin
+      super-admin-password: admin
+```
+
+:::

--- a/versioned_docs/version-2.0/developer-guide/core/run.md
+++ b/versioned_docs/version-2.0/developer-guide/core/run.md
@@ -105,7 +105,7 @@ halo:
 5. 最终访问 `http://localhost:8090/console` 即可进入控制台。访问 `http://localhost:8090` 即可进入站点首页。
 
 :::info
-开发环境下，超级管理员的默认用户名为 `admin`，默认密码为 `admin`。可通过修改 `application-dev.yaml` 配置文件进行更改：
+开发环境下，超级管理员的默认用户名为 `admin`，默认密码为 `admin`。也可通过修改 `application-dev.yaml` 配置文件进行更改：
 
 ```yaml
 halo:

--- a/versioned_docs/version-2.1/developer-guide/core/run.md
+++ b/versioned_docs/version-2.1/developer-guide/core/run.md
@@ -103,3 +103,16 @@ halo:
     ```
 
 5. 最终访问 `http://localhost:8090/console` 即可进入控制台。访问 `http://localhost:8090` 即可进入站点首页。
+
+:::info
+开发环境下，超级管理员的默认用户名为 `admin`，默认密码为 `admin`。可通过修改 `application-dev.yaml` 配置文件进行更改：
+
+```yaml
+halo:
+  security:
+    initializer:
+      super-admin-username: admin
+      super-admin-password: admin
+```
+
+:::

--- a/versioned_docs/version-2.1/developer-guide/core/run.md
+++ b/versioned_docs/version-2.1/developer-guide/core/run.md
@@ -105,7 +105,7 @@ halo:
 5. 最终访问 `http://localhost:8090/console` 即可进入控制台。访问 `http://localhost:8090` 即可进入站点首页。
 
 :::info
-开发环境下，超级管理员的默认用户名为 `admin`，默认密码为 `admin`。可通过修改 `application-dev.yaml` 配置文件进行更改：
+开发环境下，超级管理员的默认用户名为 `admin`，默认密码为 `admin`。也可通过修改 `application-dev.yaml` 配置文件进行更改：
 
 ```yaml
 halo:

--- a/versioned_docs/version-2.2/developer-guide/core/run.md
+++ b/versioned_docs/version-2.2/developer-guide/core/run.md
@@ -103,3 +103,16 @@ halo:
     ```
 
 5. 最终访问 `http://localhost:8090/console` 即可进入控制台。访问 `http://localhost:8090` 即可进入站点首页。
+
+:::info
+开发环境下，超级管理员的默认用户名为 `admin`，默认密码为 `admin`。可通过修改 `application-dev.yaml` 配置文件进行更改：
+
+```yaml
+halo:
+  security:
+    initializer:
+      super-admin-username: admin
+      super-admin-password: admin
+```
+
+:::

--- a/versioned_docs/version-2.2/developer-guide/core/run.md
+++ b/versioned_docs/version-2.2/developer-guide/core/run.md
@@ -105,7 +105,7 @@ halo:
 5. 最终访问 `http://localhost:8090/console` 即可进入控制台。访问 `http://localhost:8090` 即可进入站点首页。
 
 :::info
-开发环境下，超级管理员的默认用户名为 `admin`，默认密码为 `admin`。可通过修改 `application-dev.yaml` 配置文件进行更改：
+开发环境下，超级管理员的默认用户名为 `admin`，默认密码为 `admin`。也可通过修改 `application-dev.yaml` 配置文件进行更改：
 
 ```yaml
 halo:


### PR DESCRIPTION
添加开发环境下初始管理员用户名和密码的提示

/kind documentation

Fixes #188 

```release-note
None
```