### PR TITLE
fix: incorrect hightlight number of docker compose example code block

### DIFF
--- a/docs/getting-started/install/docker-compose.md
+++ b/docs/getting-started/install/docker-compose.md
@@ -49,7 +49,7 @@ import DockerArgs from "./slots/docker-args.md"
 
     1. 创建 Halo + PostgreSQL 的实例：
 
-    ```yaml {18-28,45} title="~/halo/docker-compose.yaml"
+    ```yaml {24-34,51} title="~/halo/docker-compose.yaml"
     version: "3"
 
     services:
@@ -111,7 +111,7 @@ import DockerArgs from "./slots/docker-args.md"
 
     2. 创建 Halo + MySQL 的实例：
 
-    ```yaml {18-28,53} title="~/halo/docker-compose.yaml"
+    ```yaml {24-34,59} title="~/halo/docker-compose.yaml"
     version: "3"
 
     services:
@@ -179,7 +179,7 @@ import DockerArgs from "./slots/docker-args.md"
 
     3. 仅创建 Halo 实例（使用默认的 H2 数据库，**不推荐用于生产环境，建议体验和测试的时候使用**）：
 
-    ```yaml {13-20} title="~/halo/docker-compose.yaml"
+    ```yaml {19-24} title="~/halo/docker-compose.yaml"
     version: "3"
 
     services:

--- a/versioned_docs/version-2.2/getting-started/install/docker-compose.md
+++ b/versioned_docs/version-2.2/getting-started/install/docker-compose.md
@@ -49,7 +49,7 @@ import DockerArgs from "./slots/docker-args.md"
 
     1. 创建 Halo + PostgreSQL 的实例：
 
-    ```yaml {18-28,45} title="~/halo/docker-compose.yaml"
+    ```yaml {24-34,51} title="~/halo/docker-compose.yaml"
     version: "3"
 
     services:
@@ -111,7 +111,7 @@ import DockerArgs from "./slots/docker-args.md"
 
     2. 创建 Halo + MySQL 的实例：
 
-    ```yaml {18-28,53} title="~/halo/docker-compose.yaml"
+    ```yaml {24-34,59} title="~/halo/docker-compose.yaml"
     version: "3"
 
     services:
@@ -179,7 +179,7 @@ import DockerArgs from "./slots/docker-args.md"
 
     3. 仅创建 Halo 实例（使用默认的 H2 数据库，**不推荐用于生产环境，建议体验和测试的时候使用**）：
 
-    ```yaml {13-20} title="~/halo/docker-compose.yaml"
+    ```yaml {19-24} title="~/halo/docker-compose.yaml"
     version: "3"
 
     services:


### PR DESCRIPTION
/kind documentation

修复由 https://github.com/halo-dev/docs/pull/189 导致的 Docker Compose 代码块高亮行错误的问题。

before:

<img width="727" alt="image" src="https://user-images.githubusercontent.com/21301288/221819214-fd261a4a-c6bf-4228-8377-bbb3a7aebb55.png">

after:

<img width="917" alt="image" src="https://user-images.githubusercontent.com/21301288/221819329-5087b143-e93c-4eff-a101-2d003c8f2e2a.png">

```release-note
None
```