### PR TITLE
docs: add configuration examples for the Windows platform in the plugin-related documents

### DIFF
--- a/docs/developer-guide/plugin/hello-world.md
+++ b/docs/developer-guide/plugin/hello-world.md
@@ -30,12 +30,21 @@ Halo 提供了一个模板仓库用于创建插件：
 然后在 `src/main/resources` 下创建一个 `application-local.yaml` 文件并做如下配置：
 
 ```yaml
+# macOS / Linux
 halo:
   plugin:
     runtime-mode: development
     fixed-plugin-path:
       # 配置为插件绝对路径
-      - /Users/guqing/halo-plugin-hello-world
+      - /path/to/plugin-xxx
+
+# Windows
+halo:
+  plugin:
+    runtime-mode: development
+    fixed-plugin-path:
+      # 配置为插件绝对路径
+      - C:\path\to\plugin-xxx
 ```
 
 使用此 local profile 启动 Halo：

--- a/docs/developer-guide/plugin/hello-world.md
+++ b/docs/developer-guide/plugin/hello-world.md
@@ -36,7 +36,7 @@ halo:
     runtime-mode: development
     fixed-plugin-path:
       # 配置为插件绝对路径
-      - /path/to/plugin-xxx
+      - /Users/guqing/halo-plugin-hello-world
 
 # Windows
 halo:
@@ -44,7 +44,7 @@ halo:
     runtime-mode: development
     fixed-plugin-path:
       # 配置为插件绝对路径
-      - C:\path\to\plugin-xxx
+      - C:\Users\guqing\halo-plugin-hello-world
 ```
 
 使用此 local profile 启动 Halo：

--- a/docs/developer-guide/plugin/runtime-mode.md
+++ b/docs/developer-guide/plugin/runtime-mode.md
@@ -23,11 +23,20 @@ halo:
 而如果你想以 `DEVELOPMENT` 运行插件或开发插件则将 `runtime-mode` 修改为 `development`，同时配置 `fixed-plugin-path` 为插件项目路径，可以配置多个。
 
 ```yaml
+# macOS / Linux
+plugin:
+  runtime-mode: development
+  fixed-plugin-path:
+    # 配置为插件绝对路径
+    - /path/to/plugin-xxx
+
+# Windows
 halo:
   plugin:
-    runtime-mode: deployment
+    runtime-mode: development
     fixed-plugin-path:
-      - /path/to/your/plugin/plugin-starter
+      # 配置为插件绝对路径
+      - C:\path\to\plugin-xxx
 ```
 
 :::tip Note

--- a/docs/developer-guide/plugin/runtime-mode.md
+++ b/docs/developer-guide/plugin/runtime-mode.md
@@ -28,7 +28,7 @@ plugin:
   runtime-mode: development
   fixed-plugin-path:
     # 配置为插件绝对路径
-    - /path/to/plugin-xxx
+    - /Users/guqing/halo-plugin-hello-world
 
 # Windows
 halo:
@@ -36,7 +36,7 @@ halo:
     runtime-mode: development
     fixed-plugin-path:
       # 配置为插件绝对路径
-      - C:\path\to\plugin-xxx
+      - C:\Users\guqing\halo-plugin-hello-world
 ```
 
 :::tip Note

--- a/versioned_docs/version-2.5/developer-guide/plugin/hello-world.md
+++ b/versioned_docs/version-2.5/developer-guide/plugin/hello-world.md
@@ -30,12 +30,21 @@ Halo 提供了一个模板仓库用于创建插件：
 然后在 `src/main/resources` 下创建一个 `application-local.yaml` 文件并做如下配置：
 
 ```yaml
+# macOS / Linux
 halo:
   plugin:
     runtime-mode: development
     fixed-plugin-path:
       # 配置为插件绝对路径
       - /Users/guqing/halo-plugin-hello-world
+        
+# Windows
+halo:
+  plugin:
+    runtime-mode: development
+    fixed-plugin-path:
+      # 配置为插件绝对路径
+      - C:\Users\guqing\halo-plugin-hello-world
 ```
 
 使用此 local profile 启动 Halo：

--- a/versioned_docs/version-2.5/developer-guide/plugin/hello-world.md
+++ b/versioned_docs/version-2.5/developer-guide/plugin/hello-world.md
@@ -36,7 +36,7 @@ halo:
     runtime-mode: development
     fixed-plugin-path:
       # 配置为插件绝对路径
-      - /path/to/plugin-xxx
+      - /Users/guqing/halo-plugin-hello-world
         
 # Windows
 halo:
@@ -44,7 +44,7 @@ halo:
     runtime-mode: development
     fixed-plugin-path:
       # 配置为插件绝对路径
-      - C:\path\to\plugin-xxx
+      - C:\Users\guqing\halo-plugin-hello-world
 ```
 
 使用此 local profile 启动 Halo：

--- a/versioned_docs/version-2.5/developer-guide/plugin/hello-world.md
+++ b/versioned_docs/version-2.5/developer-guide/plugin/hello-world.md
@@ -36,7 +36,7 @@ halo:
     runtime-mode: development
     fixed-plugin-path:
       # 配置为插件绝对路径
-      - /Users/guqing/halo-plugin-hello-world
+      - /path/to/plugin-xxx
         
 # Windows
 halo:
@@ -44,7 +44,7 @@ halo:
     runtime-mode: development
     fixed-plugin-path:
       # 配置为插件绝对路径
-      - C:\Users\guqing\halo-plugin-hello-world
+      - C:\path\to\plugin-xxx
 ```
 
 使用此 local profile 启动 Halo：

--- a/versioned_docs/version-2.5/developer-guide/plugin/runtime-mode.md
+++ b/versioned_docs/version-2.5/developer-guide/plugin/runtime-mode.md
@@ -23,11 +23,21 @@ halo:
 而如果你想以 `DEVELOPMENT` 运行插件或开发插件则将 `runtime-mode` 修改为 `development`，同时配置 `fixed-plugin-path` 为插件项目路径，可以配置多个。
 
 ```yaml
+# macOS / Linux
+plugin:
+  runtime-mode: development
+  fixed-plugin-path:
+    # 配置为插件绝对路径
+    - /Users/guqing/halo-plugin-hello-world
+
+# Windows
 halo:
   plugin:
-    runtime-mode: deployment
+    runtime-mode: development
     fixed-plugin-path:
-      - /path/to/your/plugin/plugin-starter
+      # 配置为插件绝对路径
+      - C:\Users\guqing\halo-plugin-hello-world
+
 ```
 
 :::tip Note

--- a/versioned_docs/version-2.5/developer-guide/plugin/runtime-mode.md
+++ b/versioned_docs/version-2.5/developer-guide/plugin/runtime-mode.md
@@ -28,7 +28,7 @@ plugin:
   runtime-mode: development
   fixed-plugin-path:
     # 配置为插件绝对路径
-    - /path/to/plugin-xxx
+    - /Users/guqing/halo-plugin-hello-world
 
 # Windows
 halo:
@@ -36,7 +36,7 @@ halo:
     runtime-mode: development
     fixed-plugin-path:
       # 配置为插件绝对路径
-      - C:\path\to\plugin-xxx
+      - C:\Users\guqing\halo-plugin-hello-world
 
 ```
 

--- a/versioned_docs/version-2.5/developer-guide/plugin/runtime-mode.md
+++ b/versioned_docs/version-2.5/developer-guide/plugin/runtime-mode.md
@@ -28,7 +28,7 @@ plugin:
   runtime-mode: development
   fixed-plugin-path:
     # 配置为插件绝对路径
-    - /Users/guqing/halo-plugin-hello-world
+    - /path/to/plugin-xxx
 
 # Windows
 halo:
@@ -36,7 +36,7 @@ halo:
     runtime-mode: development
     fixed-plugin-path:
       # 配置为插件绝对路径
-      - C:\Users\guqing\halo-plugin-hello-world
+      - C:\path\to\plugin-xxx
 
 ```
 


### PR DESCRIPTION
Halo 插件开发 Windows 环境下插件绝对路径的补充

Ref #218 

/kind documentation


```release-note
None
```