### PR TITLE
chore: update site configs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -6,8 +6,8 @@ const VersionsArchived = require("./versionsArchived.json");
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: "Halo Documents",
-  tagline: "Halo 博客系统的文档站点",
+  title: "Halo 文档",
+  tagline: "Halo 的文档站点",
   url: "https://docs.halo.run",
   baseUrl: "/",
   onBrokenLinks: "warn",
@@ -49,6 +49,18 @@ const config = {
         sitemap: {
           changefreq: "weekly",
           priority: 0.5,
+          ignorePatterns: [
+            "/1.4/**",
+            "/1.5/**",
+            "/1.6/**",
+            "/2.0/**",
+            "/2.1/**",
+            "/2.2/**",
+            "/2.3/**",
+            "/2.4/**",
+            "/2.5/**",
+            "/2.6/**",
+          ],
         },
         googleAnalytics: {
           trackingID: "UA-110780416-7",
@@ -69,7 +81,7 @@ const config = {
         },
       },
       navbar: {
-        title: "Halo Documents",
+        title: "Halo 文档",
         logo: {
           alt: "Halo Logo",
           src: "https://halo.run/upload/2021/03/Adaptive256-463ca9b92e2d40268431018c07735842.png",
@@ -114,7 +126,7 @@ const config = {
       },
       footer: {
         style: "dark",
-        copyright: `Copyright © 2022 <a target="_blank" href="https://www.fit2cloud.com/">FIT2CLOUD 飞致云</a>. Built with Docusaurus.`,
+        copyright: `Copyright © 2023 凌霞软件. Built with Docusaurus.`,
         links: [
           {
             title: "关于",
@@ -124,8 +136,8 @@ const config = {
                 href: "https://halo.run",
               },
               {
-                label: "主题仓库",
-                href: "https://halo.run/themes.html",
+                label: "应用市场",
+                href: "https://halo.run/store/apps",
               },
               {
                 label: "GitHub 组织",
@@ -151,10 +163,6 @@ const config = {
               {
                 label: "微信公众号",
                 href: "https://halo.run/upload/2021/03/B3C27F16-4890-4633-81CC-20BA4B28F94F-2415126255c749b290312ca22d9bdeb0.jpeg",
-              },
-              {
-                label: "微信群申请",
-                href: "https://wj.qq.com/s2/8434455/9170/",
               },
               {
                 label: "GitHub Issues",

--- a/i18n/zh-Hans/code.json
+++ b/i18n/zh-Hans/code.json
@@ -25,10 +25,6 @@
     "message": "请联系原始链接来源网站的所有者，并告知他们链接已损坏。",
     "description": "The 2nd paragraph of the 404 page"
   },
-  "theme.BackToTopButton.buttonAriaLabel": {
-    "message": "回到顶部",
-    "description": "The ARIA label for the back to top button"
-  },
   "theme.admonition.note": {
     "message": "备注",
     "description": "The default label used for the Note admonition (:::note)"
@@ -68,6 +64,10 @@
   "theme.blog.paginator.olderEntries": {
     "message": "较旧的博文",
     "description": "The label used to navigate to the older blog posts page (next page)"
+  },
+  "theme.BackToTopButton.buttonAriaLabel": {
+    "message": "回到顶部",
+    "description": "The ARIA label for the back to top button"
   },
   "theme.blog.post.paginator.navAriaLabel": {
     "message": "博文分页导航",
@@ -133,8 +133,9 @@
     "message": "{nDocsTagged}「{tagName}」",
     "description": "The title of the page for a docs tag"
   },
-  "theme.docs.versionBadge.label": {
-    "message": "版本：{versionLabel}"
+  "theme.common.editThisPage": {
+    "message": "编辑此页",
+    "description": "The link label to edit the current page"
   },
   "theme.docs.versions.unreleasedVersionLabel": {
     "message": "此为 {siteTitle} {versionLabel} 版尚未发行的文档。",
@@ -152,9 +153,8 @@
     "message": "最新版本",
     "description": "The label used for the latest version suggestion link label"
   },
-  "theme.common.editThisPage": {
-    "message": "编辑此页",
-    "description": "The link label to edit the current page"
+  "theme.docs.versionBadge.label": {
+    "message": "版本：{versionLabel}"
   },
   "theme.common.headingLinkTitle": {
     "message": "{heading}的直接链接",
@@ -220,10 +220,6 @@
     "message": "本页总览",
     "description": "The label used by the button on the collapsible TOC component"
   },
-  "theme.blog.post.readingTime.plurals": {
-    "message": "阅读需 {readingTime} 分钟",
-    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
-  },
   "theme.blog.post.readMore": {
     "message": "阅读更多",
     "description": "The label used in blog post item excerpts to link to full blog posts"
@@ -231,6 +227,10 @@
   "theme.blog.post.readMoreLabel": {
     "message": "阅读 {title} 的全文",
     "description": "The ARIA label for the link to full blog posts from excerpts"
+  },
+  "theme.blog.post.readingTime.plurals": {
+    "message": "阅读需 {readingTime} 分钟",
+    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
   },
   "theme.docs.breadcrumbs.home": {
     "message": "主页面",
@@ -256,6 +256,10 @@
     "message": "← 回到主菜单",
     "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
   },
+  "theme.docs.sidebar.toggleSidebarButtonAriaLabel": {
+    "message": "切换导航栏",
+    "description": "The ARIA label for hamburger menu button of mobile navigation"
+  },
   "theme.docs.sidebar.expandButtonTitle": {
     "message": "展开侧边栏",
     "description": "The ARIA label and title attribute for expand button of doc sidebar"
@@ -264,9 +268,8 @@
     "message": "展开侧边栏",
     "description": "The ARIA label and title attribute for expand button of doc sidebar"
   },
-  "theme.docs.sidebar.toggleSidebarButtonAriaLabel": {
-    "message": "切换导航栏",
-    "description": "The ARIA label for hamburger menu button of mobile navigation"
+  "theme.SearchBar.seeAll": {
+    "message": "查看全部 {count} 个结果"
   },
   "theme.SearchPage.documentsFound.plurals": {
     "message": "找到 {count} 份文件",
@@ -395,9 +398,6 @@
   "theme.SearchModal.placeholder": {
     "message": "搜索文档",
     "description": "The placeholder of the input of the DocSearch pop-up modal"
-  },
-  "theme.SearchBar.seeAll": {
-    "message": "查看全部 {count} 个结果"
   },
   "theme.common.skipToMainContent": {
     "message": "跳到主要内容",

--- a/i18n/zh-Hans/docusaurus-theme-classic/footer.json
+++ b/i18n/zh-Hans/docusaurus-theme-classic/footer.json
@@ -11,9 +11,9 @@
     "message": "官网",
     "description": "The label of footer link with label=官网 linking to https://halo.run"
   },
-  "link.item.label.主题仓库": {
-    "message": "主题仓库",
-    "description": "The label of footer link with label=主题仓库 linking to https://halo.run/themes.html"
+  "link.item.label.应用市场": {
+    "message": "应用市场",
+    "description": "The label of footer link with label=应用市场 linking to https://halo.run/store/apps"
   },
   "link.item.label.GitHub 组织": {
     "message": "GitHub 组织",
@@ -35,10 +35,6 @@
     "message": "微信公众号",
     "description": "The label of footer link with label=微信公众号 linking to https://halo.run/upload/2021/03/B3C27F16-4890-4633-81CC-20BA4B28F94F-2415126255c749b290312ca22d9bdeb0.jpeg"
   },
-  "link.item.label.微信群申请": {
-    "message": "微信群申请",
-    "description": "The label of footer link with label=微信群申请 linking to https://wj.qq.com/s2/8434455/9170/"
-  },
   "link.item.label.GitHub Issues": {
     "message": "GitHub Issues",
     "description": "The label of footer link with label=GitHub Issues linking to https://github.com/halo-dev/halo/issues"
@@ -52,7 +48,7 @@
     "description": "The label of footer link with label=Telegram Group linking to https://t.me/HaloBlog"
   },
   "copyright": {
-    "message": "Copyright © 2022 <a target=\"_blank\" href=\"https://www.fit2cloud.com/\">FIT2CLOUD 飞致云</a>. Built with Docusaurus.",
+    "message": "Copyright © 2023 凌霞软件. Built with Docusaurus.",
     "description": "The footer copyright"
   }
 }

--- a/i18n/zh-Hans/docusaurus-theme-classic/navbar.json
+++ b/i18n/zh-Hans/docusaurus-theme-classic/navbar.json
@@ -1,6 +1,6 @@
 {
   "title": {
-    "message": "Halo Documents",
+    "message": "Halo 文档",
     "description": "The title in the navbar"
   },
   "item.label.官网": {


### PR DESCRIPTION
1. 修改标题为 `Halo 文档`。
2. Sitemap 排除旧文档的索引，防止 Algolia 额度不够导致无法建索引。
3. 修改页面底部的 Copyright。
4. 修改底部的主题仓库为应用市场。


/kind improvement

```release-note
None
```