### PR TITLE
docs: update the instructions for the initial administrator in the deployment document

### DIFF
--- a/docs/getting-started/first-post.md
+++ b/docs/getting-started/first-post.md
@@ -8,11 +8,7 @@ description: 安装完成后，如何写下第一篇文章。
 
 ## 登录管理端
 
-浏览器访问 `/console` 即可进入 Halo 管理端。用户名密码为部署在配置文件中时设置的 `halo.security.initializer.superadminusername` 和 `halo.security.initializer.superadminpassword`。
-
-:::info
-如果你在安装时没有设置 `halo.security.initializer.superadminpassword` 变量或忘记了设置的密码，可以参考[常见问题中的忘记密码章节](../user-guide/faq.md#忘记密码怎么办)进行处理。
-:::
+浏览器访问 `/console` 即可进入 Halo 管理端。
 
 ## 新建文章
 

--- a/docs/getting-started/install/docker-compose.md
+++ b/docs/getting-started/install/docker-compose.md
@@ -54,7 +54,7 @@ import DockerArgs from "./slots/docker-args.md"
 
     1. 创建 Halo + PostgreSQL 的实例：
 
-    ```yaml {24-34,51} title="~/halo/docker-compose.yaml"
+    ```yaml {24-30,47} title="~/halo/docker-compose.yaml"
     version: "3"
 
     services:
@@ -85,10 +85,6 @@ import DockerArgs from "./slots/docker-args.md"
           - --spring.sql.init.platform=postgresql
           # 外部访问地址，请根据实际需要修改
           - --halo.external-url=http://localhost:8090/
-          # 初始化的超级管理员用户名
-          - --halo.security.initializer.superadminusername=admin
-          # 初始化的超级管理员密码
-          - --halo.security.initializer.superadminpassword=P@88w0rd
       halodb:
         image: postgres:latest
         container_name: halodb
@@ -116,7 +112,7 @@ import DockerArgs from "./slots/docker-args.md"
 
     2. 创建 Halo + MySQL 的实例：
 
-    ```yaml {24-34,59} title="~/halo/docker-compose.yaml"
+    ```yaml {24-30,55} title="~/halo/docker-compose.yaml"
     version: "3"
 
     services:
@@ -147,10 +143,6 @@ import DockerArgs from "./slots/docker-args.md"
           - --spring.sql.init.platform=mysql
           # 外部访问地址，请根据实际需要修改
           - --halo.external-url=http://localhost:8090/
-          # 初始化的超级管理员用户名
-          - --halo.security.initializer.superadminusername=admin
-          # 初始化的超级管理员密码
-          - --halo.security.initializer.superadminpassword=P@88w0rd
 
       halodb:
         image: mysql:8.0.31
@@ -205,14 +197,10 @@ import DockerArgs from "./slots/docker-args.md"
         command:
           # 外部访问地址，请根据实际需要修改
           - --halo.external-url=http://localhost:8090/
-          # 初始化的超级管理员用户名
-          - --halo.security.initializer.superadminusername=admin
-          # 初始化的超级管理员密码
-          - --halo.security.initializer.superadminpassword=P@88w0rd
     ```
     4. 仅创建 Halo 实例（使用已有外部数据库，MySQL 为例）：
     
-    ```yaml {8,21-24} title="~/halo/docker-compose.yaml"
+    ```yaml {8,12-20} title="~/halo/docker-compose.yaml"
     version: "3"
 
     services:
@@ -231,13 +219,8 @@ import DockerArgs from "./slots/docker-args.md"
           - --spring.sql.init.platform=mysql
           # 外部访问地址，请根据实际需要修改
           - --halo.external-url=http://localhost:8090/
-          # 初始化的超级管理员用户名
-          - --halo.security.initializer.superadminusername=admin
-          # 初始化的超级管理员密码
-          - --halo.security.initializer.superadminpassword=P@88w0rd
           # 端口号 默认8090
           - --server.port=8090
-
     ```
 
   参数详解：
@@ -256,7 +239,7 @@ import DockerArgs from "./slots/docker-args.md"
   docker-compose logs -f
   ```
 
-4. 用浏览器访问 `/console` 即可进入 Halo 管理页面，用户名和密码为在 `docker-compose.yaml` 文件中设置的 `superadminusername` 和 `superadminpassword`。
+4. 用浏览器访问 /console 即可进入 Halo 管理页面，首次启动会进入初始化页面。
 
   :::tip
   如果需要配置域名访问，建议先配置好反向代理以及域名解析再进行初始化。如果通过 `http://ip:端口号` 的形式无法访问，请到服务器厂商后台将运行的端口号添加到安全组，如果服务器使用了 Linux 面板，请检查此 Linux 面板是否有还有安全组配置，需要同样将端口号添加到安全组。
@@ -366,10 +349,6 @@ services:
     command:
       # 外部访问地址，请根据实际需要修改
       - --halo.external-url=https://yourdomain.com
-      # 初始化的超级管理员用户名
-      - --halo.security.initializer.superadminusername=admin
-      # 初始化的超级管理员密码
-      - --halo.security.initializer.superadminpassword=P@88w0rd
     labels:
       traefik.enable: "true"
       traefik.docker.network: traefik

--- a/docs/getting-started/install/docker.md
+++ b/docs/getting-started/install/docker.md
@@ -48,9 +48,7 @@ import DockerArgs from "./slots/docker-args.md"
       -p 8090:8090 \
       -v ~/.halo2:/root/.halo2 \
       halohub/halo:2.8 \
-      --halo.external-url=http://localhost:8090/ \
-      --halo.security.initializer.superadminusername=admin \
-      --halo.security.initializer.superadminpassword=P@88w0rd
+      --halo.external-url=http://localhost:8090/
     ```
 
     :::info
@@ -67,7 +65,7 @@ import DockerArgs from "./slots/docker-args.md"
 
     <DockerArgs />
 
-1. 用浏览器访问 `/console` 即可进入 Halo 管理页面，用户名和密码为启动参数中的 `superadminusername` 和 `superadminpassword`。
+1. 用浏览器访问 `/console` 即可进入 Halo 管理页面，首次启动会进入初始化页面。
 
     :::tip
     如果需要配置域名访问，建议先配置好反向代理以及域名解析再进行初始化。如果通过 `http://ip:端口号` 的形式无法访问，请到服务器厂商后台将运行的端口号添加到安全组，如果服务器使用了 Linux 面板，请检查此 Linux 面板是否有还有安全组配置，需要同样将端口号添加到安全组。
@@ -107,7 +105,5 @@ import DockerArgs from "./slots/docker-args.md"
       -p 8090:8090 \
       -v ~/.halo2:/root/.halo2 \
       halohub/halo:2.8 \
-      --halo.external-url=http://localhost:8090/ \
-      --halo.security.initializer.superadminusername=admin \
-      --halo.security.initializer.superadminpassword=P@88w0rd  
+      --halo.external-url=http://localhost:8090/
     ```

--- a/docs/getting-started/install/other/traefik.md
+++ b/docs/getting-started/install/other/traefik.md
@@ -107,10 +107,6 @@ services:
     command:
       # 外部访问地址，请根据实际需要修改
       - --halo.external-url=https://yourdomain.com
-      # 初始化的超级管理员用户名
-      - --halo.security.initializer.superadminusername=admin
-      # 初始化的超级管理员密码
-      - --halo.security.initializer.superadminpassword=P@88w0rd
     labels:
       traefik.enable: "true"
       traefik.docker.network: traefik

--- a/docs/getting-started/install/slots/docker-args.md
+++ b/docs/getting-started/install/slots/docker-args.md
@@ -5,8 +5,6 @@
 | `spring.r2dbc.password`                        | 数据库密码                                                                                                                                                                                                            |
 | `spring.sql.init.platform`                     | 数据库平台名称，支持 `postgresql`、`mysql`、`h2`                                                                                                                                                                      |
 | `halo.external-url`                            | 外部访问链接，如果需要在公网访问，需要配置为实际访问地址                                                                                                                                                              |
-| `halo.security.initializer.superadminusername` | 初始超级管理员用户名                                                                                                                                                                                                  |
-| `halo.security.initializer.superadminpassword` | 初始超级管理员密码                                                                                                                                                                                                    |
 | `halo.cache.page.disabled`                     | 是否禁用页面缓存，默认为禁用，如需页面缓存可以手动添加此配置，并设置为 `false`。<br />开启缓存之后，在登录的情况下不会经过缓存，且默认一个小时会清理掉不活跃的缓存，也可以在 Console 仪表盘的快捷访问中手动清理缓存。 |
 
 数据库配置：


### PR DESCRIPTION
更新部署文档，移除通过参数的形式设置初始管理员。

/kind documentation

Fixes #241 

```release-note
None 
```