### PR TITLE
Update docker-compose.md

### DIFF
--- a/versioned_docs/version-2.9/getting-started/install/docker-compose.md
+++ b/versioned_docs/version-2.9/getting-started/install/docker-compose.md
@@ -145,7 +145,7 @@ import DockerArgs from "./slots/docker-args.md"
           - --halo.external-url=http://localhost:8090/
 
       halodb:
-        image: mysql:8.0.31
+        image: mysql:latest
         container_name: halodb
         restart: on-failure:3
         networks:

--- a/versioned_docs/version-2.9/getting-started/install/docker-compose.md
+++ b/versioned_docs/version-2.9/getting-started/install/docker-compose.md
@@ -151,7 +151,7 @@ import DockerArgs from "./slots/docker-args.md"
         networks:
           halo_network:
         command: 
-          - --default-authentication-plugin=mysql_native_password
+          - --default-authentication-plugin=caching_sha2_password
           - --character-set-server=utf8mb4
           - --collation-server=utf8mb4_general_ci
           - --explicit_defaults_for_timestamp=true


### PR DESCRIPTION
使用caching_sha2_password代替mysql_native_password。

以解决使用My SQL的Docker镜像报Plugin mysql_native_password reported: ''mysql_native_password' is deprecated and will be removed in a future release. Please use caching_sha2_password instead'。告警的问题。