### PR TITLE
Update MySQL to 8.1.0 to prevent mysql_native_password warning

### DIFF
--- a/docs/getting-started/install/docker-compose.md
+++ b/docs/getting-started/install/docker-compose.md
@@ -145,13 +145,13 @@ import DockerArgs from "./slots/docker-args.md"
           - --halo.external-url=http://localhost:8090/
 
       halodb:
-        image: mysql:8.0.31
+        image: mysql:8.1.0
         container_name: halodb
         restart: on-failure:3
         networks:
           halo_network:
         command: 
-          - --default-authentication-plugin=mysql_native_password
+          - --default-authentication-plugin=caching_sha2_password
           - --character-set-server=utf8mb4
           - --collation-server=utf8mb4_general_ci
           - --explicit_defaults_for_timestamp=true


### PR DESCRIPTION
使用caching_sha2_password代替mysql_native_password。

以解决使用My SQL的Docker镜像报Plugin mysql_native_password reported: ''mysql_native_password' is deprecated and will be removed in a future release. Please use caching_sha2_password instead'。告警的问题。

```release-note
None
```