### PR TITLE
Remove useless deploy step

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -49,14 +49,3 @@ jobs:
 
     - run: pnpm install
     - run: pnpm build
-
-    - name: Deploy
-      uses: easingthemes/ssh-deploy@main
-      env:
-        SSH_PRIVATE_KEY: ${{ secrets.SERVER_SSH_KEY }}
-        ARGS: "-avzr --delete"
-        SOURCE: "build/"
-        REMOTE_HOST: ${{ secrets.SERVER_HOST }}
-        REMOTE_PORT: ${{ secrets.SERVER_PORT }}
-        REMOTE_USER: ${{ secrets.SERVER_USER }}
-        TARGET: "/data/wwwroot/docs.halo.run"


### PR DESCRIPTION
/kind cleanup

Halo docs site has been deployed by Cloudflare Page. The deploy step in GitHub workflow is currently not useful.

```release-note
None
```