### PR TITLE
fix: menu api example in theme dev docs

### DIFF
--- a/docs/developer-guide/theme/annotations.md
+++ b/docs/developer-guide/theme/annotations.md
@@ -19,7 +19,7 @@ title: 模型元数据
   <ul th:with="menuItems = ${menu.menuItems}">
     <li th:each="menuItem : ${menuItems}">
       <i th:class="${#annotations.get(menuItem, 'icon')}"></i>
-      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.spec.displayName}"></a>
+      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.status.displayName}"></a>
     </li>
    </ul>
 </div>
@@ -38,7 +38,7 @@ title: 模型元数据
   <ul th:with="menuItems = ${menu.menuItems}">
     <li th:each="menuItem : ${menuItems}">
       <i th:class="${#annotations.getOrDefault(menuItem, 'icon', 'fa')}"></i>
-      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.spec.displayName}"></a>
+      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.status.displayName}"></a>
     </li>
    </ul>
 </div>
@@ -57,7 +57,7 @@ title: 模型元数据
   <ul th:with="menuItems = ${menu.menuItems}">
     <li th:each="menuItem : ${menuItems}">
       <i th:if="${#annotations.contains(menuItem, 'icon')}" th:class="${#annotations.get(menuItem, 'icon')}"></i>
-      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.spec.displayName}"></a>
+      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.status.displayName}"></a>
     </li>
    </ul>
 </div>

--- a/docs/developer-guide/theme/finder-apis/menu.md
+++ b/docs/developer-guide/theme/finder-apis/menu.md
@@ -32,7 +32,7 @@ menuFinder.getByName(name)
     <li th:each="menuItem : ${menuItems}">
       <a
         th:href="@{${menuItem.status.href}}"
-        th:text="${menuItem.spec.displayName}"
+        th:text="${menuItem.status.displayName}"
         th:target="${menuItem.spec.target?.value}"
       >
       </a>
@@ -67,7 +67,7 @@ menuFinder.getPrimary()
     <li th:each="menuItem : ${menuItems}">
       <a
         th:href="@{${menuItem.status.href}}"
-        th:text="${menuItem.spec.displayName}"
+        th:text="${menuItem.status.displayName}"
         th:target="${menuItem.spec.target?.value}"
       >
       </a>

--- a/versioned_docs/version-2.0/developer-guide/theme/finder-apis/menu.md
+++ b/versioned_docs/version-2.0/developer-guide/theme/finder-apis/menu.md
@@ -30,7 +30,7 @@ menuFinder.getByName(name)
 <div th:with="menu = ${menuFinder.getByName('menu-foo')}">
   <ul th:with="menuItems = ${menu.menuItems}">
     <li th:each="menuItem : ${menuItems}">
-      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.spec.displayName}"></a>
+      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.status.displayName}"></a>
     </li>
    </ul>
 </div>
@@ -60,7 +60,7 @@ menuFinder.getPrimary()
 <div th:with="menu = ${menuFinder.getPrimary()}">
   <ul th:with="menuItems = ${menu.menuItems}">
     <li th:each="menuItem : ${menuItems}">
-      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.spec.displayName}"></a>
+      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.status.displayName}"></a>
     </li>
    </ul>
 </div>

--- a/versioned_docs/version-2.1/developer-guide/theme/annotations.md
+++ b/versioned_docs/version-2.1/developer-guide/theme/annotations.md
@@ -19,7 +19,7 @@ title: 模型元数据
   <ul th:with="menuItems = ${menu.menuItems}">
     <li th:each="menuItem : ${menuItems}">
       <i th:class="${#annotations.get(menuItem, 'icon')}"></i>
-      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.spec.displayName}"></a>
+      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.status.displayName}"></a>
     </li>
    </ul>
 </div>
@@ -38,7 +38,7 @@ title: 模型元数据
   <ul th:with="menuItems = ${menu.menuItems}">
     <li th:each="menuItem : ${menuItems}">
       <i th:class="${#annotations.getOrDefault(menuItem, 'icon', 'fa')}"></i>
-      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.spec.displayName}"></a>
+      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.status.displayName}"></a>
     </li>
    </ul>
 </div>
@@ -57,7 +57,7 @@ title: 模型元数据
   <ul th:with="menuItems = ${menu.menuItems}">
     <li th:each="menuItem : ${menuItems}">
       <i th:if="${#annotations.contains(menuItem, 'icon')}" th:class="${#annotations.get(menuItem, 'icon')}"></i>
-      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.spec.displayName}"></a>
+      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.status.displayName}"></a>
     </li>
    </ul>
 </div>

--- a/versioned_docs/version-2.1/developer-guide/theme/finder-apis/menu.md
+++ b/versioned_docs/version-2.1/developer-guide/theme/finder-apis/menu.md
@@ -32,7 +32,7 @@ menuFinder.getByName(name)
     <li th:each="menuItem : ${menuItems}">
       <a
         th:href="@{${menuItem.status.href}}"
-        th:text="${menuItem.spec.displayName}"
+        th:text="${menuItem.status.displayName}"
         th:target="${menuItem.spec.target?.value}"
       >
       </a>
@@ -67,7 +67,7 @@ menuFinder.getPrimary()
     <li th:each="menuItem : ${menuItems}">
       <a
         th:href="@{${menuItem.status.href}}"
-        th:text="${menuItem.spec.displayName}"
+        th:text="${menuItem.status.displayName}"
         th:target="${menuItem.spec.target?.value}"
       >
       </a>

--- a/versioned_docs/version-2.2/developer-guide/theme/annotations.md
+++ b/versioned_docs/version-2.2/developer-guide/theme/annotations.md
@@ -19,7 +19,7 @@ title: 模型元数据
   <ul th:with="menuItems = ${menu.menuItems}">
     <li th:each="menuItem : ${menuItems}">
       <i th:class="${#annotations.get(menuItem, 'icon')}"></i>
-      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.spec.displayName}"></a>
+      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.status.displayName}"></a>
     </li>
    </ul>
 </div>
@@ -38,7 +38,7 @@ title: 模型元数据
   <ul th:with="menuItems = ${menu.menuItems}">
     <li th:each="menuItem : ${menuItems}">
       <i th:class="${#annotations.getOrDefault(menuItem, 'icon', 'fa')}"></i>
-      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.spec.displayName}"></a>
+      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.status.displayName}"></a>
     </li>
    </ul>
 </div>
@@ -57,7 +57,7 @@ title: 模型元数据
   <ul th:with="menuItems = ${menu.menuItems}">
     <li th:each="menuItem : ${menuItems}">
       <i th:if="${#annotations.contains(menuItem, 'icon')}" th:class="${#annotations.get(menuItem, 'icon')}"></i>
-      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.spec.displayName}"></a>
+      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.status.displayName}"></a>
     </li>
    </ul>
 </div>

--- a/versioned_docs/version-2.2/developer-guide/theme/finder-apis/menu.md
+++ b/versioned_docs/version-2.2/developer-guide/theme/finder-apis/menu.md
@@ -32,7 +32,7 @@ menuFinder.getByName(name)
     <li th:each="menuItem : ${menuItems}">
       <a
         th:href="@{${menuItem.status.href}}"
-        th:text="${menuItem.spec.displayName}"
+        th:text="${menuItem.status.displayName}"
         th:target="${menuItem.spec.target?.value}"
       >
       </a>
@@ -67,7 +67,7 @@ menuFinder.getPrimary()
     <li th:each="menuItem : ${menuItems}">
       <a
         th:href="@{${menuItem.status.href}}"
-        th:text="${menuItem.spec.displayName}"
+        th:text="${menuItem.status.displayName}"
         th:target="${menuItem.spec.target?.value}"
       >
       </a>

--- a/versioned_docs/version-2.3/developer-guide/theme/annotations.md
+++ b/versioned_docs/version-2.3/developer-guide/theme/annotations.md
@@ -19,7 +19,7 @@ title: 模型元数据
   <ul th:with="menuItems = ${menu.menuItems}">
     <li th:each="menuItem : ${menuItems}">
       <i th:class="${#annotations.get(menuItem, 'icon')}"></i>
-      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.spec.displayName}"></a>
+      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.status.displayName}"></a>
     </li>
    </ul>
 </div>
@@ -38,7 +38,7 @@ title: 模型元数据
   <ul th:with="menuItems = ${menu.menuItems}">
     <li th:each="menuItem : ${menuItems}">
       <i th:class="${#annotations.getOrDefault(menuItem, 'icon', 'fa')}"></i>
-      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.spec.displayName}"></a>
+      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.status.displayName}"></a>
     </li>
    </ul>
 </div>
@@ -57,7 +57,7 @@ title: 模型元数据
   <ul th:with="menuItems = ${menu.menuItems}">
     <li th:each="menuItem : ${menuItems}">
       <i th:if="${#annotations.contains(menuItem, 'icon')}" th:class="${#annotations.get(menuItem, 'icon')}"></i>
-      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.spec.displayName}"></a>
+      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.status.displayName}"></a>
     </li>
    </ul>
 </div>

--- a/versioned_docs/version-2.3/developer-guide/theme/finder-apis/menu.md
+++ b/versioned_docs/version-2.3/developer-guide/theme/finder-apis/menu.md
@@ -32,7 +32,7 @@ menuFinder.getByName(name)
     <li th:each="menuItem : ${menuItems}">
       <a
         th:href="@{${menuItem.status.href}}"
-        th:text="${menuItem.spec.displayName}"
+        th:text="${menuItem.status.displayName}"
         th:target="${menuItem.spec.target?.value}"
       >
       </a>
@@ -67,7 +67,7 @@ menuFinder.getPrimary()
     <li th:each="menuItem : ${menuItems}">
       <a
         th:href="@{${menuItem.status.href}}"
-        th:text="${menuItem.spec.displayName}"
+        th:text="${menuItem.status.displayName}"
         th:target="${menuItem.spec.target?.value}"
       >
       </a>

--- a/versioned_docs/version-2.4/developer-guide/theme/annotations.md
+++ b/versioned_docs/version-2.4/developer-guide/theme/annotations.md
@@ -19,7 +19,7 @@ title: 模型元数据
   <ul th:with="menuItems = ${menu.menuItems}">
     <li th:each="menuItem : ${menuItems}">
       <i th:class="${#annotations.get(menuItem, 'icon')}"></i>
-      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.spec.displayName}"></a>
+      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.status.displayName}"></a>
     </li>
    </ul>
 </div>
@@ -38,7 +38,7 @@ title: 模型元数据
   <ul th:with="menuItems = ${menu.menuItems}">
     <li th:each="menuItem : ${menuItems}">
       <i th:class="${#annotations.getOrDefault(menuItem, 'icon', 'fa')}"></i>
-      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.spec.displayName}"></a>
+      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.status.displayName}"></a>
     </li>
    </ul>
 </div>
@@ -57,7 +57,7 @@ title: 模型元数据
   <ul th:with="menuItems = ${menu.menuItems}">
     <li th:each="menuItem : ${menuItems}">
       <i th:if="${#annotations.contains(menuItem, 'icon')}" th:class="${#annotations.get(menuItem, 'icon')}"></i>
-      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.spec.displayName}"></a>
+      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.status.displayName}"></a>
     </li>
    </ul>
 </div>

--- a/versioned_docs/version-2.4/developer-guide/theme/finder-apis/menu.md
+++ b/versioned_docs/version-2.4/developer-guide/theme/finder-apis/menu.md
@@ -32,7 +32,7 @@ menuFinder.getByName(name)
     <li th:each="menuItem : ${menuItems}">
       <a
         th:href="@{${menuItem.status.href}}"
-        th:text="${menuItem.spec.displayName}"
+        th:text="${menuItem.status.displayName}"
         th:target="${menuItem.spec.target?.value}"
       >
       </a>
@@ -67,7 +67,7 @@ menuFinder.getPrimary()
     <li th:each="menuItem : ${menuItems}">
       <a
         th:href="@{${menuItem.status.href}}"
-        th:text="${menuItem.spec.displayName}"
+        th:text="${menuItem.status.displayName}"
         th:target="${menuItem.spec.target?.value}"
       >
       </a>

--- a/versioned_docs/version-2.5/developer-guide/theme/annotations.md
+++ b/versioned_docs/version-2.5/developer-guide/theme/annotations.md
@@ -19,7 +19,7 @@ title: 模型元数据
   <ul th:with="menuItems = ${menu.menuItems}">
     <li th:each="menuItem : ${menuItems}">
       <i th:class="${#annotations.get(menuItem, 'icon')}"></i>
-      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.spec.displayName}"></a>
+      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.status.displayName}"></a>
     </li>
    </ul>
 </div>
@@ -38,7 +38,7 @@ title: 模型元数据
   <ul th:with="menuItems = ${menu.menuItems}">
     <li th:each="menuItem : ${menuItems}">
       <i th:class="${#annotations.getOrDefault(menuItem, 'icon', 'fa')}"></i>
-      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.spec.displayName}"></a>
+      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.status.displayName}"></a>
     </li>
    </ul>
 </div>
@@ -57,7 +57,7 @@ title: 模型元数据
   <ul th:with="menuItems = ${menu.menuItems}">
     <li th:each="menuItem : ${menuItems}">
       <i th:if="${#annotations.contains(menuItem, 'icon')}" th:class="${#annotations.get(menuItem, 'icon')}"></i>
-      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.spec.displayName}"></a>
+      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.status.displayName}"></a>
     </li>
    </ul>
 </div>

--- a/versioned_docs/version-2.5/developer-guide/theme/finder-apis/menu.md
+++ b/versioned_docs/version-2.5/developer-guide/theme/finder-apis/menu.md
@@ -32,7 +32,7 @@ menuFinder.getByName(name)
     <li th:each="menuItem : ${menuItems}">
       <a
         th:href="@{${menuItem.status.href}}"
-        th:text="${menuItem.spec.displayName}"
+        th:text="${menuItem.status.displayName}"
         th:target="${menuItem.spec.target?.value}"
       >
       </a>
@@ -67,7 +67,7 @@ menuFinder.getPrimary()
     <li th:each="menuItem : ${menuItems}">
       <a
         th:href="@{${menuItem.status.href}}"
-        th:text="${menuItem.spec.displayName}"
+        th:text="${menuItem.status.displayName}"
         th:target="${menuItem.spec.target?.value}"
       >
       </a>

--- a/versioned_docs/version-2.6/developer-guide/theme/annotations.md
+++ b/versioned_docs/version-2.6/developer-guide/theme/annotations.md
@@ -19,7 +19,7 @@ title: 模型元数据
   <ul th:with="menuItems = ${menu.menuItems}">
     <li th:each="menuItem : ${menuItems}">
       <i th:class="${#annotations.get(menuItem, 'icon')}"></i>
-      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.spec.displayName}"></a>
+      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.status.displayName}"></a>
     </li>
    </ul>
 </div>
@@ -38,7 +38,7 @@ title: 模型元数据
   <ul th:with="menuItems = ${menu.menuItems}">
     <li th:each="menuItem : ${menuItems}">
       <i th:class="${#annotations.getOrDefault(menuItem, 'icon', 'fa')}"></i>
-      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.spec.displayName}"></a>
+      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.status.displayName}"></a>
     </li>
    </ul>
 </div>
@@ -57,7 +57,7 @@ title: 模型元数据
   <ul th:with="menuItems = ${menu.menuItems}">
     <li th:each="menuItem : ${menuItems}">
       <i th:if="${#annotations.contains(menuItem, 'icon')}" th:class="${#annotations.get(menuItem, 'icon')}"></i>
-      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.spec.displayName}"></a>
+      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.status.displayName}"></a>
     </li>
    </ul>
 </div>

--- a/versioned_docs/version-2.6/developer-guide/theme/finder-apis/menu.md
+++ b/versioned_docs/version-2.6/developer-guide/theme/finder-apis/menu.md
@@ -32,7 +32,7 @@ menuFinder.getByName(name)
     <li th:each="menuItem : ${menuItems}">
       <a
         th:href="@{${menuItem.status.href}}"
-        th:text="${menuItem.spec.displayName}"
+        th:text="${menuItem.status.displayName}"
         th:target="${menuItem.spec.target?.value}"
       >
       </a>
@@ -67,7 +67,7 @@ menuFinder.getPrimary()
     <li th:each="menuItem : ${menuItems}">
       <a
         th:href="@{${menuItem.status.href}}"
-        th:text="${menuItem.spec.displayName}"
+        th:text="${menuItem.status.displayName}"
         th:target="${menuItem.spec.target?.value}"
       >
       </a>

--- a/versioned_docs/version-2.7/developer-guide/theme/annotations.md
+++ b/versioned_docs/version-2.7/developer-guide/theme/annotations.md
@@ -19,7 +19,7 @@ title: 模型元数据
   <ul th:with="menuItems = ${menu.menuItems}">
     <li th:each="menuItem : ${menuItems}">
       <i th:class="${#annotations.get(menuItem, 'icon')}"></i>
-      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.spec.displayName}"></a>
+      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.status.displayName}"></a>
     </li>
    </ul>
 </div>
@@ -38,7 +38,7 @@ title: 模型元数据
   <ul th:with="menuItems = ${menu.menuItems}">
     <li th:each="menuItem : ${menuItems}">
       <i th:class="${#annotations.getOrDefault(menuItem, 'icon', 'fa')}"></i>
-      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.spec.displayName}"></a>
+      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.status.displayName}"></a>
     </li>
    </ul>
 </div>
@@ -57,7 +57,7 @@ title: 模型元数据
   <ul th:with="menuItems = ${menu.menuItems}">
     <li th:each="menuItem : ${menuItems}">
       <i th:if="${#annotations.contains(menuItem, 'icon')}" th:class="${#annotations.get(menuItem, 'icon')}"></i>
-      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.spec.displayName}"></a>
+      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.status.displayName}"></a>
     </li>
    </ul>
 </div>

--- a/versioned_docs/version-2.7/developer-guide/theme/finder-apis/menu.md
+++ b/versioned_docs/version-2.7/developer-guide/theme/finder-apis/menu.md
@@ -32,7 +32,7 @@ menuFinder.getByName(name)
     <li th:each="menuItem : ${menuItems}">
       <a
         th:href="@{${menuItem.status.href}}"
-        th:text="${menuItem.spec.displayName}"
+        th:text="${menuItem.status.displayName}"
         th:target="${menuItem.spec.target?.value}"
       >
       </a>
@@ -67,7 +67,7 @@ menuFinder.getPrimary()
     <li th:each="menuItem : ${menuItems}">
       <a
         th:href="@{${menuItem.status.href}}"
-        th:text="${menuItem.spec.displayName}"
+        th:text="${menuItem.status.displayName}"
         th:target="${menuItem.spec.target?.value}"
       >
       </a>

--- a/versioned_docs/version-2.8/developer-guide/theme/annotations.md
+++ b/versioned_docs/version-2.8/developer-guide/theme/annotations.md
@@ -19,7 +19,7 @@ title: 模型元数据
   <ul th:with="menuItems = ${menu.menuItems}">
     <li th:each="menuItem : ${menuItems}">
       <i th:class="${#annotations.get(menuItem, 'icon')}"></i>
-      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.spec.displayName}"></a>
+      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.status.displayName}"></a>
     </li>
    </ul>
 </div>
@@ -38,7 +38,7 @@ title: 模型元数据
   <ul th:with="menuItems = ${menu.menuItems}">
     <li th:each="menuItem : ${menuItems}">
       <i th:class="${#annotations.getOrDefault(menuItem, 'icon', 'fa')}"></i>
-      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.spec.displayName}"></a>
+      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.status.displayName}"></a>
     </li>
    </ul>
 </div>
@@ -57,7 +57,7 @@ title: 模型元数据
   <ul th:with="menuItems = ${menu.menuItems}">
     <li th:each="menuItem : ${menuItems}">
       <i th:if="${#annotations.contains(menuItem, 'icon')}" th:class="${#annotations.get(menuItem, 'icon')}"></i>
-      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.spec.displayName}"></a>
+      <a th:href="@{${menuItem.status.href}}" th:text="${menuItem.status.displayName}"></a>
     </li>
    </ul>
 </div>

--- a/versioned_docs/version-2.8/developer-guide/theme/finder-apis/menu.md
+++ b/versioned_docs/version-2.8/developer-guide/theme/finder-apis/menu.md
@@ -32,7 +32,7 @@ menuFinder.getByName(name)
     <li th:each="menuItem : ${menuItems}">
       <a
         th:href="@{${menuItem.status.href}}"
-        th:text="${menuItem.spec.displayName}"
+        th:text="${menuItem.status.displayName}"
         th:target="${menuItem.spec.target?.value}"
       >
       </a>
@@ -67,7 +67,7 @@ menuFinder.getPrimary()
     <li th:each="menuItem : ${menuItems}">
       <a
         th:href="@{${menuItem.status.href}}"
-        th:text="${menuItem.spec.displayName}"
+        th:text="${menuItem.status.displayName}"
         th:target="${menuItem.spec.target?.value}"
       >
       </a>


### PR DESCRIPTION
日常主题开发中，我们应该使用菜单最终生成到名字

```release-note
None
````