### PR TITLE
docs: lock postgres version in docker compose example

### DIFF
--- a/docs/getting-started/install/docker-compose.md
+++ b/docs/getting-started/install/docker-compose.md
@@ -86,7 +86,7 @@ import DockerArgs from "./slots/docker-args.md"
           # 外部访问地址，请根据实际需要修改
           - --halo.external-url=http://localhost:8090/
       halodb:
-        image: postgres:latest
+        image: postgres:15.4
         container_name: halodb
         restart: on-failure:3
         networks:

--- a/versioned_docs/version-2.0/getting-started/install/docker-compose.md
+++ b/versioned_docs/version-2.0/getting-started/install/docker-compose.md
@@ -80,7 +80,7 @@ import DockerEnv from "./slots/docker-env.md"
           - HALO_SECURITY_INITIALIZER_SUPERADMINPASSWORD=P@88w0rd
 
       halodb:
-        image: postgres:latest
+        image: postgres:15.4
         container_name: halodb
         restart: on-failure:3
         networks:

--- a/versioned_docs/version-2.1/getting-started/install/docker-compose.md
+++ b/versioned_docs/version-2.1/getting-started/install/docker-compose.md
@@ -79,7 +79,7 @@ import DockerArgs from "./slots/docker-args.md"
           # 初始化的超级管理员密码
           - --halo.security.initializer.superadminpassword=P@88w0rd
       halodb:
-        image: postgres:latest
+        image: postgres:15.4
         container_name: halodb
         restart: on-failure:3
         networks:

--- a/versioned_docs/version-2.2/getting-started/install/docker-compose.md
+++ b/versioned_docs/version-2.2/getting-started/install/docker-compose.md
@@ -85,7 +85,7 @@ import DockerArgs from "./slots/docker-args.md"
           # 初始化的超级管理员密码
           - --halo.security.initializer.superadminpassword=P@88w0rd
       halodb:
-        image: postgres:latest
+        image: postgres:15.4
         container_name: halodb
         restart: on-failure:3
         networks:

--- a/versioned_docs/version-2.3/getting-started/install/docker-compose.md
+++ b/versioned_docs/version-2.3/getting-started/install/docker-compose.md
@@ -85,7 +85,7 @@ import DockerArgs from "./slots/docker-args.md"
           # 初始化的超级管理员密码
           - --halo.security.initializer.superadminpassword=P@88w0rd
       halodb:
-        image: postgres:latest
+        image: postgres:15.4
         container_name: halodb
         restart: on-failure:3
         networks:

--- a/versioned_docs/version-2.4/getting-started/install/docker-compose.md
+++ b/versioned_docs/version-2.4/getting-started/install/docker-compose.md
@@ -90,7 +90,7 @@ import DockerArgs from "./slots/docker-args.md"
           # 初始化的超级管理员密码
           - --halo.security.initializer.superadminpassword=P@88w0rd
       halodb:
-        image: postgres:latest
+        image: postgres:15.4
         container_name: halodb
         restart: on-failure:3
         networks:

--- a/versioned_docs/version-2.5/getting-started/install/docker-compose.md
+++ b/versioned_docs/version-2.5/getting-started/install/docker-compose.md
@@ -90,7 +90,7 @@ import DockerArgs from "./slots/docker-args.md"
           # 初始化的超级管理员密码
           - --halo.security.initializer.superadminpassword=P@88w0rd
       halodb:
-        image: postgres:latest
+        image: postgres:15.4
         container_name: halodb
         restart: on-failure:3
         networks:

--- a/versioned_docs/version-2.6/getting-started/install/docker-compose.md
+++ b/versioned_docs/version-2.6/getting-started/install/docker-compose.md
@@ -90,7 +90,7 @@ import DockerArgs from "./slots/docker-args.md"
           # 初始化的超级管理员密码
           - --halo.security.initializer.superadminpassword=P@88w0rd
       halodb:
-        image: postgres:latest
+        image: postgres:15.4
         container_name: halodb
         restart: on-failure:3
         networks:

--- a/versioned_docs/version-2.7/getting-started/install/docker-compose.md
+++ b/versioned_docs/version-2.7/getting-started/install/docker-compose.md
@@ -90,7 +90,7 @@ import DockerArgs from "./slots/docker-args.md"
           # 初始化的超级管理员密码
           - --halo.security.initializer.superadminpassword=P@88w0rd
       halodb:
-        image: postgres:latest
+        image: postgres:15.4
         container_name: halodb
         restart: on-failure:3
         networks:

--- a/versioned_docs/version-2.8/getting-started/install/docker-compose.md
+++ b/versioned_docs/version-2.8/getting-started/install/docker-compose.md
@@ -90,7 +90,7 @@ import DockerArgs from "./slots/docker-args.md"
           # 初始化的超级管理员密码
           - --halo.security.initializer.superadminpassword=P@88w0rd
       halodb:
-        image: postgres:latest
+        image: postgres:15.4
         container_name: halodb
         restart: on-failure:3
         networks:

--- a/versioned_docs/version-2.9/getting-started/install/docker-compose.md
+++ b/versioned_docs/version-2.9/getting-started/install/docker-compose.md
@@ -86,7 +86,7 @@ import DockerArgs from "./slots/docker-args.md"
           # 外部访问地址，请根据实际需要修改
           - --halo.external-url=http://localhost:8090/
       halodb:
-        image: postgres:latest
+        image: postgres:15.4
         container_name: halodb
         restart: on-failure:3
         networks:


### PR DESCRIPTION
固定 Docker Compose 文档中 postgres 的版本，防止使用 latest 标签导致跨版本不兼容。

/kind documentation

```release-note
None
```