### PR TITLE
Change mount dir of Halo container to ./halo2

### DIFF
--- a/docs/getting-started/install/docker-compose.md
+++ b/docs/getting-started/install/docker-compose.md
@@ -68,7 +68,7 @@ import DockerArgs from "./slots/docker-args.md"
         networks:
           halo_network:
         volumes:
-          - ./:/root/.halo2
+          - ./halo2:/root/.halo2
         ports:
           - "8090:8090"
         healthcheck:
@@ -126,7 +126,7 @@ import DockerArgs from "./slots/docker-args.md"
         networks:
           halo_network:
         volumes:
-          - ./:/root/.halo2
+          - ./halo2:/root/.halo2
         ports:
           - "8090:8090"
         healthcheck:
@@ -185,7 +185,7 @@ import DockerArgs from "./slots/docker-args.md"
         container_name: halo
         restart: on-failure:3
         volumes:
-          - ./:/root/.halo2
+          - ./halo2:/root/.halo2
         ports:
           - "8090:8090"
         healthcheck:
@@ -210,7 +210,7 @@ import DockerArgs from "./slots/docker-args.md"
         restart: on-failure:3
         network_mode: "host"
         volumes:
-          - ./:/root/.halo2
+          - ./halo2:/root/.halo2
         command:
           # 修改为自己已有的 MySQL 配置
           - --spring.r2dbc.url=r2dbc:pool:mysql://localhost:3306/halo
@@ -342,7 +342,7 @@ services:
     container_name: halo
     restart: on-failure:3
     volumes:
-      - ./:/root/.halo2
+      - ./halo2:/root/.halo2
     networks:
       - traefik
       - halo

--- a/docs/getting-started/install/other/traefik.md
+++ b/docs/getting-started/install/other/traefik.md
@@ -100,7 +100,7 @@ services:
     container_name: halo
     restart: on-failure:3
     volumes:
-      - ./:/root/.halo2
+      - ./halo2:/root/.halo2
     networks:
       - traefik
       - halo


### PR DESCRIPTION
#### What this PR does / why we need it:

目前 Halo 容器挂载目录配置 `./:/root/.halo2` 容易让用户无意在 Halo 工作目录添加一些其他无关目录，例如：Nginx 也挂载到当前目录。这可能会导致无法正常使用备份功能。目前也无法预知未来可能会发生什么样的错误。


#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/4637

#### Does this PR introduce a user-facing change?

```release-note
修改 Halo 容器工作目录挂载目标目录为 ./halo2
```