### PR TITLE
docs: remove unnecessary tips

### DIFF
--- a/docs/getting-started/install/jar-file.md
+++ b/docs/getting-started/install/jar-file.md
@@ -144,10 +144,6 @@ title: 使用 JAR 文件部署
    cd ~/app && java -jar halo.jar --spring.config.location="optional:classpath:/;optional:file:$HOME/.halo2/"
    ```
 
-   :::info
-   `/home/halo/.halo2/application.yaml` 为你的配置文件的绝对路径，请确保地址正确。
-   :::
-
 7. 如果没有观察到异常日志，即可尝试访问 Halo
 
    打开 `http://ip:端口号` 即可跳转到初始化页面。

--- a/versioned_docs/version-2.12/getting-started/install/jar-file.md
+++ b/versioned_docs/version-2.12/getting-started/install/jar-file.md
@@ -144,10 +144,6 @@ title: 使用 JAR 文件部署
    cd ~/app && java -jar halo.jar --spring.config.location="optional:classpath:/;optional:file:$HOME/.halo2/"
    ```
 
-   :::info
-   `/home/halo/.halo2/application.yaml` 为你的配置文件的绝对路径，请确保地址正确。
-   :::
-
 7. 如果没有观察到异常日志，即可尝试访问 Halo
 
    打开 `http://ip:端口号` 即可跳转到初始化页面。


### PR DESCRIPTION
在 https://github.com/halo-dev/docs/pull/309 中，修改配置挂载方式之后没有删除以前的提示。

/kind documentation

```release-note
None
```