### PR TITLE
Correct systemd syntax by removing double quotes

### DIFF
--- a/docs/getting-started/install/jar-file.md
+++ b/docs/getting-started/install/jar-file.md
@@ -141,7 +141,7 @@ title: 使用 JAR 文件部署
 6. 测试运行 Halo
 
    ```bash
-   cd ~/app && java -jar halo.jar --spring.config.location="optional:classpath:/;optional:file:$HOME/.halo2/"
+   cd ~/app && java -jar halo.jar --spring.config.additional-location=optional:file:$HOME/.halo2/
    ```
 
 7. 如果没有观察到异常日志，即可尝试访问 Halo
@@ -188,7 +188,7 @@ title: 使用 JAR 文件部署
    [Service]
    Type=simple
    User=USER
-   ExecStart=/usr/bin/java -server -Xms256m -Xmx256m -jar JAR_PATH --spring.config.location="optional:classpath:/;optional:file:/home/halo/.halo2/"
+   ExecStart=/usr/bin/java -server -Xms256m -Xmx256m -jar JAR_PATH --spring.config.additional-location=optional:file:/home/halo/.halo2/
    ExecStop=/bin/kill -s QUIT $MAINPID
    Restart=always
    StandOutput=syslog

--- a/versioned_docs/version-2.12/getting-started/install/jar-file.md
+++ b/versioned_docs/version-2.12/getting-started/install/jar-file.md
@@ -141,7 +141,7 @@ title: 使用 JAR 文件部署
 6. 测试运行 Halo
 
    ```bash
-   cd ~/app && java -jar halo.jar --spring.config.location="optional:classpath:/;optional:file:$HOME/.halo2/"
+   cd ~/app && java -jar halo.jar --spring.config.additional-location=optional:file:$HOME/.halo2/
    ```
 
 7. 如果没有观察到异常日志，即可尝试访问 Halo
@@ -188,7 +188,7 @@ title: 使用 JAR 文件部署
    [Service]
    Type=simple
    User=USER
-   ExecStart=/usr/bin/java -server -Xms256m -Xmx256m -jar JAR_PATH --spring.config.location="optional:classpath:/;optional:file:/home/halo/.halo2/"
+   ExecStart=/usr/bin/java -server -Xms256m -Xmx256m -jar JAR_PATH --spring.config.additional-location=optional:file:/home/halo/.halo2/
    ExecStop=/bin/kill -s QUIT $MAINPID
    Restart=always
    StandOutput=syslog


### PR DESCRIPTION
This PR removes double quotes in `ExecStart` and changes `spring.config.location` argument into `spring.config.additional-location`.

```release-note
None
```