### PR TITLE
docs: refine documentation for annotation setting name

### DIFF
--- a/docs/developer-guide/annotations-form.md
+++ b/docs/developer-guide/annotations-form.md
@@ -16,7 +16,7 @@ title: 元数据表单定义
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: content.halo.run
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.generateName`：可以不做修改，最终会以这个值当做前缀生成一个唯一的名称。
+1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 
@@ -59,7 +59,7 @@ targetRef 支持列表：
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: content.halo.run
@@ -77,7 +77,7 @@ spec:
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: ""

--- a/docs/developer-guide/annotations-form.md
+++ b/docs/developer-guide/annotations-form.md
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`
+1. `metadata.name`：唯一标识，命名规范可参考 [metadata name](./plugin/api-reference/server/extension.md#metadata-name)，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 

--- a/versioned_docs/version-2.1/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.1/developer-guide/annotations-form.md
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.name`：唯一标识，命名规范可参考 [metadata name](./plugin/api-reference/server/extension.md#metadata-name)，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
+1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 

--- a/versioned_docs/version-2.1/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.1/developer-guide/annotations-form.md
@@ -16,7 +16,7 @@ title: 元数据表单定义
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: content.halo.run
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.generateName`：可以不做修改，最终会以这个值当做前缀生成一个唯一的名称。
+1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 
@@ -59,7 +59,7 @@ targetRef 支持列表：
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: content.halo.run
@@ -77,7 +77,7 @@ spec:
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: ""

--- a/versioned_docs/version-2.1/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.1/developer-guide/annotations-form.md
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`
+1. `metadata.name`：唯一标识，命名规范可参考 [metadata name](./plugin/api-reference/server/extension.md#metadata-name)，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 

--- a/versioned_docs/version-2.10/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.10/developer-guide/annotations-form.md
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.name`：唯一标识，命名规范可参考 [metadata name](./plugin/api-reference/server/extension.md#metadata-name)，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
+1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 

--- a/versioned_docs/version-2.10/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.10/developer-guide/annotations-form.md
@@ -16,7 +16,7 @@ title: 元数据表单定义
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: content.halo.run
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.generateName`：可以不做修改，最终会以这个值当做前缀生成一个唯一的名称。
+1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 
@@ -59,7 +59,7 @@ targetRef 支持列表：
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: content.halo.run
@@ -77,7 +77,7 @@ spec:
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: ""

--- a/versioned_docs/version-2.10/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.10/developer-guide/annotations-form.md
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`
+1. `metadata.name`：唯一标识，命名规范可参考 [metadata name](./plugin/api-reference/server/extension.md#metadata-name)，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 

--- a/versioned_docs/version-2.11/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.11/developer-guide/annotations-form.md
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.name`：唯一标识，命名规范可参考 [metadata name](./plugin/api-reference/server/extension.md#metadata-name)，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
+1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 

--- a/versioned_docs/version-2.11/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.11/developer-guide/annotations-form.md
@@ -16,7 +16,7 @@ title: 元数据表单定义
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: content.halo.run
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.generateName`：可以不做修改，最终会以这个值当做前缀生成一个唯一的名称。
+1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 
@@ -59,7 +59,7 @@ targetRef 支持列表：
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: content.halo.run
@@ -77,7 +77,7 @@ spec:
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: ""

--- a/versioned_docs/version-2.11/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.11/developer-guide/annotations-form.md
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`
+1. `metadata.name`：唯一标识，命名规范可参考 [metadata name](./plugin/api-reference/server/extension.md#metadata-name)，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 

--- a/versioned_docs/version-2.12/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.12/developer-guide/annotations-form.md
@@ -16,7 +16,7 @@ title: 元数据表单定义
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: content.halo.run
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.generateName`：可以不做修改，最终会以这个值当做前缀生成一个唯一的名称。
+1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 
@@ -59,7 +59,7 @@ targetRef 支持列表：
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: content.halo.run
@@ -77,7 +77,7 @@ spec:
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: ""

--- a/versioned_docs/version-2.12/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.12/developer-guide/annotations-form.md
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`
+1. `metadata.name`：唯一标识，命名规范可参考 [metadata name](./plugin/api-reference/server/extension.md#metadata-name)，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 

--- a/versioned_docs/version-2.2/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.2/developer-guide/annotations-form.md
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.name`：唯一标识，命名规范可参考 [metadata name](./plugin/api-reference/server/extension.md#metadata-name)，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
+1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 

--- a/versioned_docs/version-2.2/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.2/developer-guide/annotations-form.md
@@ -16,7 +16,7 @@ title: 元数据表单定义
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: content.halo.run
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.generateName`：可以不做修改，最终会以这个值当做前缀生成一个唯一的名称。
+1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 
@@ -59,7 +59,7 @@ targetRef 支持列表：
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: content.halo.run
@@ -77,7 +77,7 @@ spec:
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: ""

--- a/versioned_docs/version-2.2/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.2/developer-guide/annotations-form.md
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`
+1. `metadata.name`：唯一标识，命名规范可参考 [metadata name](./plugin/api-reference/server/extension.md#metadata-name)，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 

--- a/versioned_docs/version-2.3/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.3/developer-guide/annotations-form.md
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.name`：唯一标识，命名规范可参考 [metadata name](./plugin/api-reference/server/extension.md#metadata-name)，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
+1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 

--- a/versioned_docs/version-2.3/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.3/developer-guide/annotations-form.md
@@ -16,7 +16,7 @@ title: 元数据表单定义
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: content.halo.run
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.generateName`：可以不做修改，最终会以这个值当做前缀生成一个唯一的名称。
+1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 
@@ -59,7 +59,7 @@ targetRef 支持列表：
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: content.halo.run
@@ -77,7 +77,7 @@ spec:
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: ""

--- a/versioned_docs/version-2.3/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.3/developer-guide/annotations-form.md
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`
+1. `metadata.name`：唯一标识，命名规范可参考 [metadata name](./plugin/api-reference/server/extension.md#metadata-name)，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 

--- a/versioned_docs/version-2.4/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.4/developer-guide/annotations-form.md
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.name`：唯一标识，命名规范可参考 [metadata name](./plugin/api-reference/server/extension.md#metadata-name)，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
+1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 

--- a/versioned_docs/version-2.4/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.4/developer-guide/annotations-form.md
@@ -16,7 +16,7 @@ title: 元数据表单定义
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: content.halo.run
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.generateName`：可以不做修改，最终会以这个值当做前缀生成一个唯一的名称。
+1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 
@@ -59,7 +59,7 @@ targetRef 支持列表：
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: content.halo.run
@@ -77,7 +77,7 @@ spec:
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: ""

--- a/versioned_docs/version-2.4/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.4/developer-guide/annotations-form.md
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`
+1. `metadata.name`：唯一标识，命名规范可参考 [metadata name](./plugin/api-reference/server/extension.md#metadata-name)，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 

--- a/versioned_docs/version-2.5/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.5/developer-guide/annotations-form.md
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.name`：唯一标识，命名规范可参考 [metadata name](./plugin/api-reference/server/extension.md#metadata-name)，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
+1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 

--- a/versioned_docs/version-2.5/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.5/developer-guide/annotations-form.md
@@ -16,7 +16,7 @@ title: 元数据表单定义
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: content.halo.run
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.generateName`：可以不做修改，最终会以这个值当做前缀生成一个唯一的名称。
+1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 
@@ -59,7 +59,7 @@ targetRef 支持列表：
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: content.halo.run
@@ -77,7 +77,7 @@ spec:
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: ""

--- a/versioned_docs/version-2.5/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.5/developer-guide/annotations-form.md
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`
+1. `metadata.name`：唯一标识，命名规范可参考 [metadata name](./plugin/api-reference/server/extension.md#metadata-name)，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 

--- a/versioned_docs/version-2.6/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.6/developer-guide/annotations-form.md
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.name`：唯一标识，命名规范可参考 [metadata name](./plugin/api-reference/server/extension.md#metadata-name)，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
+1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 

--- a/versioned_docs/version-2.6/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.6/developer-guide/annotations-form.md
@@ -16,7 +16,7 @@ title: 元数据表单定义
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: content.halo.run
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.generateName`：可以不做修改，最终会以这个值当做前缀生成一个唯一的名称。
+1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 
@@ -59,7 +59,7 @@ targetRef 支持列表：
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: content.halo.run
@@ -77,7 +77,7 @@ spec:
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: ""

--- a/versioned_docs/version-2.6/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.6/developer-guide/annotations-form.md
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`
+1. `metadata.name`：唯一标识，命名规范可参考 [metadata name](./plugin/api-reference/server/extension.md#metadata-name)，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 

--- a/versioned_docs/version-2.7/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.7/developer-guide/annotations-form.md
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.name`：唯一标识，命名规范可参考 [metadata name](./plugin/api-reference/server/extension.md#metadata-name)，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
+1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 

--- a/versioned_docs/version-2.7/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.7/developer-guide/annotations-form.md
@@ -16,7 +16,7 @@ title: 元数据表单定义
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: content.halo.run
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.generateName`：可以不做修改，最终会以这个值当做前缀生成一个唯一的名称。
+1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 
@@ -59,7 +59,7 @@ targetRef 支持列表：
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: content.halo.run
@@ -77,7 +77,7 @@ spec:
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: ""

--- a/versioned_docs/version-2.7/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.7/developer-guide/annotations-form.md
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`
+1. `metadata.name`：唯一标识，命名规范可参考 [metadata name](./plugin/api-reference/server/extension.md#metadata-name)，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 

--- a/versioned_docs/version-2.8/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.8/developer-guide/annotations-form.md
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.name`：唯一标识，命名规范可参考 [metadata name](./plugin/api-reference/server/extension.md#metadata-name)，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
+1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 

--- a/versioned_docs/version-2.8/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.8/developer-guide/annotations-form.md
@@ -16,7 +16,7 @@ title: 元数据表单定义
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: content.halo.run
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.generateName`：可以不做修改，最终会以这个值当做前缀生成一个唯一的名称。
+1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 
@@ -59,7 +59,7 @@ targetRef 支持列表：
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: content.halo.run
@@ -77,7 +77,7 @@ spec:
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: ""

--- a/versioned_docs/version-2.8/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.8/developer-guide/annotations-form.md
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`
+1. `metadata.name`：唯一标识，命名规范可参考 [metadata name](./plugin/api-reference/server/extension.md#metadata-name)，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 

--- a/versioned_docs/version-2.9/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.9/developer-guide/annotations-form.md
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.name`：唯一标识，命名规范可参考 [metadata name](./plugin/api-reference/server/extension.md#metadata-name)，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
+1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 

--- a/versioned_docs/version-2.9/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.9/developer-guide/annotations-form.md
@@ -16,7 +16,7 @@ title: 元数据表单定义
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: content.halo.run
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.generateName`：可以不做修改，最终会以这个值当做前缀生成一个唯一的名称。
+1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 
@@ -59,7 +59,7 @@ targetRef 支持列表：
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: content.halo.run
@@ -77,7 +77,7 @@ spec:
 apiVersion: v1alpha1
 kind: AnnotationSetting
 metadata:
-  generateName: annotation-setting-
+  name: my-annotation-setting
 spec:
   targetRef:
     group: ""

--- a/versioned_docs/version-2.9/developer-guide/annotations-form.md
+++ b/versioned_docs/version-2.9/developer-guide/annotations-form.md
@@ -36,7 +36,7 @@ spec:
 
 字段说明：
 
-1. `metadata.name`：唯一标识，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`
+1. `metadata.name`：唯一标识，命名规范可参考 [metadata name](./plugin/api-reference/server/extension.md#metadata-name)，为了尽可能避免冲突，建议自定义前缀以及追加随机字符串，如：`theme-earth-post-wanfs5`。
 2. `spec.targetRef`：模型的关联，即为哪个模型添加元数据表单，目前支持的模型可查看下方的列表。
 3. `spec.formSchema`：表单的定义，使用 FormKit Schema 来定义。虽然我们使用的 YAML，但与 FormKit Schema 完全一致。
 


### PR DESCRIPTION
修改《元数据表单定义》文档中关于 metadata.name 的描述。

Fixes https://github.com/halo-dev/docs/issues/298

/kind documentation

```release-note
None
```