### PR TITLE
docs: add the selection attribute to handleDrop

### DIFF
--- a/docs/developer-guide/plugin/api-reference/ui/extension-points/default-editor-extension-create.md
+++ b/docs/developer-guide/plugin/api-reference/ui/extension-points/default-editor-extension-create.md
@@ -408,12 +408,14 @@ export interface DraggableItem {
     slice,
     insertPos,
     node,
+    selection,
   }: {
     view: EditorView;
     event: DragEvent;
     slice: Slice;
     insertPos: number;
     node: Node;
+    selection: Selection;
   }) => boolean | void;
   allowPropagationDownward?: boolean;   // 是否允许拖拽事件向内部传播，
 }


### PR DESCRIPTION
将 selection 属性添加至默认编辑器的 handleDrop 扩展中。相关改动查看 https://github.com/halo-dev/halo/pull/5570

/kind documentation

```release-note
None
```