### PR TITLE
docs: update r2dbc url for MariaDB

### DIFF
--- a/docs/getting-started/install/slots/docker-args.md
+++ b/docs/getting-started/install/slots/docker-args.md
@@ -13,5 +13,11 @@
 | ----------- | ---------------------------------------------------------------------------------- | -------------------------- |
 | PostgreSQL  | `r2dbc:pool:postgresql://{HOST}:{PORT}/{DATABASE}`                                 | postgresql                 |
 | MySQL       | `r2dbc:pool:mysql://{HOST}:{PORT}/{DATABASE}`                                      | mysql                      |
-| MariaDB     | `r2dbc:pool:mariadb://{HOST}:{PORT}/{DATABASE}`                                    | mysql                      |
+| MariaDB     | `r2dbc:pool:mysql://{HOST}:{PORT}/{DATABASE}`                                    | mysql                      |
 | H2 Database | `r2dbc:h2:file:///${halo.work-dir}/db/halo-next?MODE=MySQL&DB_CLOSE_ON_EXIT=FALSE` | h2                         |
+
+:::caution
+由于 MariaDB 数据库驱动目前存在问题，使用 MariaDB 数据库时也选择使用 MySQL 驱动，即链接地址格式为 `r2dbc:pool:mysql://{HOST}:{PORT}/{DATABASE}`。
+
+详情可见：<https://github.com/halo-dev/halo/issues/5534>
+:::

--- a/versioned_docs/version-2.14/getting-started/install/slots/docker-args.md
+++ b/versioned_docs/version-2.14/getting-started/install/slots/docker-args.md
@@ -13,5 +13,9 @@
 | ----------- | ---------------------------------------------------------------------------------- | -------------------------- |
 | PostgreSQL  | `r2dbc:pool:postgresql://{HOST}:{PORT}/{DATABASE}`                                 | postgresql                 |
 | MySQL       | `r2dbc:pool:mysql://{HOST}:{PORT}/{DATABASE}`                                      | mysql                      |
-| MariaDB     | `r2dbc:pool:mariadb://{HOST}:{PORT}/{DATABASE}`                                    | mysql                      |
+| MariaDB     | `r2dbc:pool:mysql://{HOST}:{PORT}/{DATABASE}`                                    | mysql                      |
 | H2 Database | `r2dbc:h2:file:///${halo.work-dir}/db/halo-next?MODE=MySQL&DB_CLOSE_ON_EXIT=FALSE` | h2                         |
+
+:::caution
+由于 MariaDB 数据库驱动目前存在问题，使用 MariaDB 数据库时也选择使用 MySQL 驱动，即链接地址格式为 `r2dbc:pool:mysql://{HOST}:{PORT}/{DATABASE}`。
+:::

--- a/versioned_docs/version-2.14/getting-started/install/slots/docker-args.md
+++ b/versioned_docs/version-2.14/getting-started/install/slots/docker-args.md
@@ -18,4 +18,6 @@
 
 :::caution
 由于 MariaDB 数据库驱动目前存在问题，使用 MariaDB 数据库时也选择使用 MySQL 驱动，即链接地址格式为 `r2dbc:pool:mysql://{HOST}:{PORT}/{DATABASE}`。
+
+详情可见：<https://github.com/halo-dev/halo/issues/5534>
 :::


### PR DESCRIPTION
根据 https://github.com/halo-dev/halo/issues/5534#issuecomment-2011499798 中提到的，临时将文档中 MariaDB 的数据库连接地址修改为使用 mysql 驱动。

```release-note
None
```