### PR TITLE
docs: remove tips related to mariadb driver

### DIFF
--- a/docs/getting-started/install/slots/_docker-args.md
+++ b/docs/getting-started/install/slots/_docker-args.md
@@ -13,11 +13,5 @@
 | ----------- | ---------------------------------------------------------------------------------- | -------------------------- |
 | PostgreSQL  | `r2dbc:pool:postgresql://{HOST}:{PORT}/{DATABASE}`                                 | postgresql                 |
 | MySQL       | `r2dbc:pool:mysql://{HOST}:{PORT}/{DATABASE}`                                      | mysql                      |
-| MariaDB     | `r2dbc:pool:mysql://{HOST}:{PORT}/{DATABASE}`                                    | mysql                      |
+| MariaDB     | `r2dbc:pool:mariadb://{HOST}:{PORT}/{DATABASE}`                                    | mariadb                    |
 | H2 Database | `r2dbc:h2:file:///${halo.work-dir}/db/halo-next?MODE=MySQL&DB_CLOSE_ON_EXIT=FALSE` | h2                         |
-
-:::caution
-由于 MariaDB 数据库驱动目前存在问题，使用 MariaDB 数据库时也选择使用 MySQL 驱动，即链接地址格式为 `r2dbc:pool:mysql://{HOST}:{PORT}/{DATABASE}`。
-
-详情可见：<https://github.com/halo-dev/halo/issues/5534>
-:::


### PR DESCRIPTION
使用 MariaDB 原生驱动无法启动的问题将在 https://github.com/halo-dev/halo/pull/6133 中修复，并发布到 2.17.0，所以移除此提示。

/kind documentation

```release-note
None
```