### PR TITLE
docs: remove halo.cache.page.disabled arg

### DIFF
--- a/docs/getting-started/install/podman.md
+++ b/docs/getting-started/install/podman.md
@@ -138,7 +138,7 @@ Podman 没有和 Docker 类似的管理进程，在低配置的主机上更友�
   Volume=/opt/podman-data/halo:/.halo
   PublishPort=127.0.0.1:8090:8090
   Image=ghcr.io/halo-dev/halo:2.16
-  Exec=--halo.external-url=https://localhost:8090 --spring.sql.init.platform=postgresql --spring.r2dbc.url=r2dbc:pool:postgresql://127.0.0.1:5432/my-db --spring.r2dbc.username=my-user --spring.r2dbc.password=my-password --halo.cache.page.disabled=false
+  Exec=--halo.external-url=https://localhost:8090 --spring.sql.init.platform=postgresql --spring.r2dbc.url=r2dbc:pool:postgresql://127.0.0.1:5432/my-db --spring.r2dbc.username=my-user --spring.r2dbc.password=my-password
 
   [Service]
   Restart=always
@@ -210,7 +210,7 @@ Podman Quadlet 解析:
   Volume=/opt/podman-data/halo:/root/.halo
   PublishPort=127.0.0.1:8090:8090
   Image=ghcr.io/halo-dev/halo:2.16
-  Exec=--halo.external-url=https://localhost:8090 --spring.sql.init.platform=postgresql --spring.r2dbc.url=r2dbc:pool:postgresql://127.0.0.1:5432/my-db --spring.r2dbc.username=my-user --spring.r2dbc.password=my-password --halo.cache.page.disabled=false
+  Exec=--halo.external-url=https://localhost:8090 --spring.sql.init.platform=postgresql --spring.r2dbc.url=r2dbc:pool:postgresql://127.0.0.1:5432/my-db --spring.r2dbc.username=my-user --spring.r2dbc.password=my-password
 
   [Service]
   Restart=always

--- a/docs/getting-started/install/slots/_docker-args.md
+++ b/docs/getting-started/install/slots/_docker-args.md
@@ -5,7 +5,6 @@
 | `spring.r2dbc.password`                        | 数据库密码                                                                                                                                                                                                            |
 | `spring.sql.init.platform`                     | 数据库平台名称，支持 `postgresql`、`mysql`、`h2`                                                                                                                                                                      |
 | `halo.external-url`                            | 外部访问链接，如果需要在公网访问，需要配置为实际访问地址                                                                                                                                                              |
-| `halo.cache.page.disabled`                     | 是否禁用页面缓存，默认为禁用，如需页面缓存可以手动添加此配置，并设置为 `false`。<br />开启缓存之后，在登录的情况下不会经过缓存，且默认一个小时会清理掉不活跃的缓存，也可以在 Console 仪表盘的快捷访问中手动清理缓存。 |
 
 数据库配置：
 


### PR DESCRIPTION
移除部署文章的 `halo.cache.page.disabled` 参数，在 2.17 中已经[移除此功能](https://github.com/halo-dev/halo/pull/6108)，后续将由 https://github.com/halo-sigs/plugin-page-cache 提供此功能。

/kind documentation

```release-note
None
```