### PR TITLE
docs: add docs for getBreadcrumbs of category finder

### DIFF
--- a/docs/developer-guide/theme/finder-apis/category.md
+++ b/docs/developer-guide/theme/finder-apis/category.md
@@ -156,6 +156,35 @@ List<[#CategoryTreeVo](#categorytreevo)>
 </ul>
 ```
 
+## getBreadcrumbs(name)
+
+```js
+categoryFinder.getBreadcrumbs('category-foo')
+```
+
+### 描述
+
+获取分类树结构的路径节点，可以通过此方法来构建面包屑导航。
+
+### 参数
+
+- `name:string` - 分类的唯一标识 `metadata.name`，必填。
+
+### 返回值
+
+List<[#CategoryVo](#categoryvo)>
+
+### 示例
+
+```html
+<div>
+  <th:block th:each="category,stats : ${categoryFinder.getBreadcrumbs(category.metadata?.name)}">
+    <a th:href="@{${category.status.permalink}}" th:text="${category.spec.displayName}"></a>
+    <span th:if="${!stats.last}">/</span>
+  </th:block>
+</div>
+```
+
 ## 类型定义
 
 ### CategoryVo

--- a/versioned_docs/version-2.17/developer-guide/theme/finder-apis/category.md
+++ b/versioned_docs/version-2.17/developer-guide/theme/finder-apis/category.md
@@ -156,6 +156,35 @@ List<[#CategoryTreeVo](#categorytreevo)>
 </ul>
 ```
 
+## getBreadcrumbs(name)
+
+```js
+categoryFinder.getBreadcrumbs('category-foo')
+```
+
+### 描述
+
+获取分类树结构的路径节点，可以通过此方法来构建面包屑导航。
+
+### 参数
+
+- `name:string` - 分类的唯一标识 `metadata.name`，必填。
+
+### 返回值
+
+List<[#CategoryVo](#categoryvo)>
+
+### 示例
+
+```html
+<div>
+  <th:block th:each="category,stats : ${categoryFinder.getBreadcrumbs(category.metadata?.name)}">
+    <a th:href="@{${category.status.permalink}}" th:text="${category.spec.displayName}"></a>
+    <span th:if="${!stats.last}">/</span>
+  </th:block>
+</div>
+```
+
 ## 类型定义
 
 ### CategoryVo


### PR DESCRIPTION
### What this PR does?
为分类 Finder API 新增的 getBreadcrumbs 方法提供文档

see also https://github.com/halo-dev/halo/pull/6135

```release-note
None
```