### PR TITLE
docs: refine docs for postFinder.listByOwner

### DIFF
--- a/docs/developer-guide/theme/finder-apis/post.md
+++ b/docs/developer-guide/theme/finder-apis/post.md
@@ -216,6 +216,36 @@ postFinder.listByTag(page, size, tag);
 </ul>
 ```
 
+## listByOwner(page,size,owner)
+
+```js
+postFinder.listByOwner(page, size, owner);
+```
+
+### 描述
+
+根据创建者用户名和分页参数获取文章列表。
+
+### 参数
+
+1. `page:int` - 分页页码，从 1 开始
+2. `size:int` - 分页条数
+3. `owner:string` - 创建者用户名 `name`
+
+### 返回值
+
+[#ListResult<ListedPostVo\>](#listresultlistedpostvo)
+
+### 示例
+
+```html
+<ul th:with="posts = ${postFinder.listByOwner(1,10,'admin')}">
+  <li th:each="post : ${posts.items}">
+    <a th:href="@{${post.status.permalink}}" th:text="${post.spec.title}"></a>
+  </li>
+</ul>
+```
+
 ## archives(page,size)
 
 ```js

--- a/versioned_docs/version-2.18/developer-guide/theme/finder-apis/post.md
+++ b/versioned_docs/version-2.18/developer-guide/theme/finder-apis/post.md
@@ -215,6 +215,35 @@ postFinder.listByTag(page, size, tag);
   </li>
 </ul>
 ```
+## listByOwner(page,size,owner)
+
+```js
+postFinder.listByOwner(page, size, owner);
+```
+
+### 描述
+
+根据创建者用户名和分页参数获取文章列表。
+
+### 参数
+
+1. `page:int` - 分页页码，从 1 开始
+2. `size:int` - 分页条数
+3. `owner:string` - 创建者用户名 `name`
+
+### 返回值
+
+[#ListResult<ListedPostVo\>](#listresultlistedpostvo)
+
+### 示例
+
+```html
+<ul th:with="posts = ${postFinder.listByOwner(1,10,'admin')}">
+  <li th:each="post : ${posts.items}">
+    <a th:href="@{${post.status.permalink}}" th:text="${post.spec.title}"></a>
+  </li>
+</ul>
+```
 
 ## archives(page,size)
 


### PR DESCRIPTION
补充根据创建者用户名和分页参数获取文章列表。

```release-note
None
```