### PR TITLE
docs: improve the display of docker-compose examples

### DIFF
--- a/docs/getting-started/install/slots/_docker-args.md
+++ b/docs/getting-started/install/slots/_docker-args.md
@@ -3,7 +3,7 @@
 | `spring.r2dbc.url`                             | 数据库连接地址，详细可查阅下方的 `数据库配置`                                                                                                                                                                         |
 | `spring.r2dbc.username`                        | 数据库用户名                                                                                                                                                                                                          |
 | `spring.r2dbc.password`                        | 数据库密码                                                                                                                                                                                                            |
-| `spring.sql.init.platform`                     | 数据库平台名称，支持 `postgresql`、`mysql`、`h2`                                                                                                                                                                      |
+| `spring.sql.init.platform`                     | 数据库平台名称，支持 `postgresql`、`mysql`、`mariadb`、`h2`                                                                                                                                                                      |
 | `halo.external-url`                            | 外部访问链接，如果需要在公网访问，需要配置为实际访问地址                                                                                                                                                              |
 
 数据库配置：

--- a/i18n/zh-Hans/code.json
+++ b/i18n/zh-Hans/code.json
@@ -9,37 +9,17 @@
     "message": "页面已崩溃。",
     "description": "The title of the fallback page when the page crashed"
   },
-  "theme.NotFound.title": {
-    "message": "找不到页面",
-    "description": "The title of the 404 page"
+  "theme.BackToTopButton.buttonAriaLabel": {
+    "message": "回到顶部",
+    "description": "The ARIA label for the back to top button"
   },
-  "theme.NotFound.p1": {
-    "message": "我们找不到您要找的页面。",
-    "description": "The first paragraph of the 404 page"
+  "theme.blog.archive.title": {
+    "message": "历史博文",
+    "description": "The page & hero title of the blog archive page"
   },
-  "theme.NotFound.p2": {
-    "message": "请联系原始链接来源网站的所有者，并告知他们链接已损坏。",
-    "description": "The 2nd paragraph of the 404 page"
-  },
-  "theme.admonition.note": {
-    "message": "备注",
-    "description": "The default label used for the Note admonition (:::note)"
-  },
-  "theme.admonition.tip": {
-    "message": "提示",
-    "description": "The default label used for the Tip admonition (:::tip)"
-  },
-  "theme.admonition.danger": {
-    "message": "危险",
-    "description": "The default label used for the Danger admonition (:::danger)"
-  },
-  "theme.admonition.info": {
-    "message": "信息",
-    "description": "The default label used for the Info admonition (:::info)"
-  },
-  "theme.admonition.caution": {
-    "message": "警告",
-    "description": "The default label used for the Caution admonition (:::warning)"
+  "theme.blog.archive.description": {
+    "message": "历史博文",
+    "description": "The page & hero description of the blog archive page"
   },
   "theme.blog.paginator.navAriaLabel": {
     "message": "博文列表分页导航",
@@ -52,18 +32,6 @@
   "theme.blog.paginator.olderEntries": {
     "message": "较旧的博文",
     "description": "The label used to navigate to the older blog posts page (next page)"
-  },
-  "theme.blog.archive.title": {
-    "message": "历史博文",
-    "description": "The page & hero title of the blog archive page"
-  },
-  "theme.blog.archive.description": {
-    "message": "历史博文",
-    "description": "The page & hero description of the blog archive page"
-  },
-  "theme.BackToTopButton.buttonAriaLabel": {
-    "message": "回到顶部",
-    "description": "The ARIA label for the back to top button"
   },
   "theme.blog.post.paginator.navAriaLabel": {
     "message": "博文分页导航",
@@ -105,7 +73,7 @@
     "message": "页面路径",
     "description": "The ARIA label for the breadcrumbs"
   },
-  "theme.docs.DocCard.categoryDescription": {
+  "theme.docs.DocCard.categoryDescription.plurals": {
     "message": "{count} 个项目",
     "description": "The default description for a category card in the generated index about how many items this category includes"
   },
@@ -168,6 +136,10 @@
     "message": "最后{byUser}{atDate}更新",
     "description": "The sentence used to display when a page has been last updated, and by who"
   },
+  "theme.NotFound.title": {
+    "message": "找不到页面",
+    "description": "The title of the 404 page"
+  },
   "theme.navbar.mobileVersionsDropdown.label": {
     "message": "选择版本",
     "description": "The label for the navbar versions dropdown on mobile view"
@@ -179,6 +151,30 @@
   "theme.AnnouncementBar.closeButtonAriaLabel": {
     "message": "关闭",
     "description": "The ARIA label for close button of announcement bar"
+  },
+  "theme.admonition.caution": {
+    "message": "警告",
+    "description": "The default label used for the Caution admonition (:::caution)"
+  },
+  "theme.admonition.danger": {
+    "message": "危险",
+    "description": "The default label used for the Danger admonition (:::danger)"
+  },
+  "theme.admonition.info": {
+    "message": "信息",
+    "description": "The default label used for the Info admonition (:::info)"
+  },
+  "theme.admonition.note": {
+    "message": "备注",
+    "description": "The default label used for the Note admonition (:::note)"
+  },
+  "theme.admonition.tip": {
+    "message": "提示",
+    "description": "The default label used for the Tip admonition (:::tip)"
+  },
+  "theme.admonition.warning": {
+    "message": "注意",
+    "description": "The default label used for the Warning admonition (:::warning)"
   },
   "theme.blog.sidebar.navAriaLabel": {
     "message": "最近博文导航",
@@ -200,21 +196,33 @@
     "message": "切换自动换行",
     "description": "The title attribute for toggle word wrapping button of code block lines"
   },
-  "theme.DocSidebarItem.toggleCollapsedCategoryAriaLabel": {
-    "message": "打开/收起侧边栏菜单「{label}」",
-    "description": "The ARIA label to toggle the collapsible sidebar category"
+  "theme.DocSidebarItem.expandCategoryAriaLabel": {
+    "message": "展开侧边栏分类 '{label}'",
+    "description": "The ARIA label to expand the sidebar category"
+  },
+  "theme.DocSidebarItem.collapseCategoryAriaLabel": {
+    "message": "折叠侧边栏分类 '{label}'",
+    "description": "The ARIA label to collapse the sidebar category"
   },
   "theme.NavBar.navAriaLabel": {
     "message": "主导航",
     "description": "The ARIA label for the main navigation"
   },
-  "theme.TOCCollapsible.toggleButtonLabel": {
-    "message": "本页总览",
-    "description": "The label used by the button on the collapsible TOC component"
+  "theme.NotFound.p1": {
+    "message": "我们找不到您要找的页面。",
+    "description": "The first paragraph of the 404 page"
+  },
+  "theme.NotFound.p2": {
+    "message": "请联系原始链接来源网站的所有者，并告知他们链接已损坏。",
+    "description": "The 2nd paragraph of the 404 page"
   },
   "theme.navbar.mobileLanguageDropdown.label": {
     "message": "选择语言",
     "description": "The label for the mobile language switcher dropdown"
+  },
+  "theme.TOCCollapsible.toggleButtonLabel": {
+    "message": "本页总览",
+    "description": "The label used by the button on the collapsible TOC component"
   },
   "theme.blog.post.readingTime.plurals": {
     "message": "阅读需 {readingTime} 分钟",
@@ -275,5 +283,13 @@
   "theme.tags.tagsPageTitle": {
     "message": "标签",
     "description": "The title of the tag list page"
+  },
+  "theme.unlistedContent.title": {
+    "message": "未列出页",
+    "description": "The unlisted content banner title"
+  },
+  "theme.unlistedContent.message": {
+    "message": "此页面未列出。搜索引擎不会对其索引，只有拥有直接链接的用户才能访问。",
+    "description": "The unlisted content banner message"
   }
 }

--- a/versioned_docs/version-2.18/getting-started/install/docker-compose.md
+++ b/versioned_docs/version-2.18/getting-started/install/docker-compose.md
@@ -3,8 +3,12 @@ title: 使用 Docker Compose 部署
 description: 使用 Docker Compose 部署
 ---
 
+```mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 import DockerArgs from "./slots/_docker-args.md"
 import DockerRegistryList from "./slots/_docker-registry-list.md"
+```
 
 :::info
 在继续操作之前，我们推荐您先阅读[《写在前面》](../prepare.md)，这可以快速帮助你了解 Halo。
@@ -35,189 +39,187 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
 
 2. 创建 `docker-compose.yaml`
 
-   此文档提供两种场景的 Docker Compose 配置文件，请根据你的需要**选择一种**。
+   此文档提供几种场景的 Docker Compose 配置文件，请根据你的需要**选择一种**。
 
    :::info
    需要注意的是，此文档为了更加方便的管理配置，所有与 Halo 相关的配置都使用 Docker 容器启动参数代替，所以无需创建 application.yaml 文件。
    :::
 
-    1. 创建 Halo + PostgreSQL 的实例：
+   <Tabs queryString="current">
+    <TabItem value="halo-postgresql" label="Halo + PostgreSQL" default>
+         ```yaml {23-29,43} title="~/halo/docker-compose.yaml"
+         version: "3"
 
-       ```yaml {23-29,43} title="~/halo/docker-compose.yaml"
-       version: "3"
+         services:
+           halo:
+             image: registry.fit2cloud.com/halo/halo:2.18
+             restart: on-failure:3
+             depends_on:
+               halodb:
+                 condition: service_healthy
+             networks:
+               halo_network:
+             volumes:
+               - ./halo2:/root/.halo2
+             ports:
+               - "8090:8090"
+             healthcheck:
+               test: ["CMD", "curl", "-f", "http://localhost:8090/actuator/health/readiness"]
+               interval: 30s
+               timeout: 5s
+               retries: 5
+               start_period: 30s
+             command:
+               - --spring.r2dbc.url=r2dbc:pool:postgresql://halodb/halo
+               - --spring.r2dbc.username=halo
+               # PostgreSQL 的密码，请保证与下方 POSTGRES_PASSWORD 的变量值一致。
+               - --spring.r2dbc.password=openpostgresql
+               - --spring.sql.init.platform=postgresql
+               # 外部访问地址，请根据实际需要修改
+               - --halo.external-url=<http://localhost:8090/>
+           halodb:
+             image: postgres:15.4
+             restart: on-failure:3
+             networks:
+               halo_network:
+             volumes:
+               - ./db:/var/lib/postgresql/data
+             healthcheck:
+               test: [ "CMD", "pg_isready" ]
+               interval: 10s
+               timeout: 5s
+               retries: 5
+             environment:
+               - POSTGRES_PASSWORD=openpostgresql
+               - POSTGRES_USER=halo
+               - POSTGRES_DB=halo
+               - PGUSER=halo
 
-       services:
-         halo:
-           image: registry.fit2cloud.com/halo/halo:2.18
-           restart: on-failure:3
-           depends_on:
-             halodb:
-               condition: service_healthy
-           networks:
-             halo_network:
-           volumes:
-             - ./halo2:/root/.halo2
-           ports:
-             - "8090:8090"
-           healthcheck:
-             test: ["CMD", "curl", "-f", "http://localhost:8090/actuator/health/readiness"]
-             interval: 30s
-             timeout: 5s
-             retries: 5
-             start_period: 30s          
-           command:
-             - --spring.r2dbc.url=r2dbc:pool:postgresql://halodb/halo
-             - --spring.r2dbc.username=halo
-             # PostgreSQL 的密码，请保证与下方 POSTGRES_PASSWORD 的变量值一致。
-             - --spring.r2dbc.password=openpostgresql
-             - --spring.sql.init.platform=postgresql
-             # 外部访问地址，请根据实际需要修改
-             - --halo.external-url=http://localhost:8090/
-         halodb:
-           image: postgres:15.4
-           restart: on-failure:3
-           networks:
-             halo_network:
-           volumes:
-             - ./db:/var/lib/postgresql/data
-           healthcheck:
-             test: [ "CMD", "pg_isready" ]
-             interval: 10s
-             timeout: 5s
-             retries: 5
-           environment:
-             - POSTGRES_PASSWORD=openpostgresql
-             - POSTGRES_USER=halo
-             - POSTGRES_DB=halo
-             - PGUSER=halo
+         networks:
+           halo_network:
+         ```
+         :::info
+         此示例的 PostgreSQL 数据库容器默认没有设置端口映射，如果需要在容器外部访问数据库，可以自行在 `halodb` 服务中添加端口映射，PostgreSQL 的端口为 `5432`。
+         :::
+    </TabItem>
+    <TabItem value="halo-mysql" label="Halo + MySQL">
+         ```yaml {23-29,51} title="~/halo/docker-compose.yaml"
+         version: "3"
 
-       networks:
-         halo_network:
-       ```
+         services:
+           halo:
+             image: registry.fit2cloud.com/halo/halo:2.18
+             restart: on-failure:3
+             depends_on:
+               halodb:
+                 condition: service_healthy
+             networks:
+               halo_network:
+             volumes:
+               - ./halo2:/root/.halo2
+             ports:
+               - "8090:8090"
+             healthcheck:
+               test: ["CMD", "curl", "-f", "http://localhost:8090/actuator/health/readiness"]
+               interval: 30s
+               timeout: 5s
+               retries: 5
+               start_period: 30s
+             command:
+               - --spring.r2dbc.url=r2dbc:pool:mysql://halodb:3306/halo
+               - --spring.r2dbc.username=root
+               # MySQL 的密码，请保证与下方 MYSQL_ROOT_PASSWORD 的变量值一致。
+               - --spring.r2dbc.password=o#DwN&JSa56
+               - --spring.sql.init.platform=mysql
+               # 外部访问地址，请根据实际需要修改
+               - --halo.external-url=http://localhost:8090/
 
-       :::info
-       此示例的 PostgreSQL 数据库容器默认没有设置端口映射，如果需要在容器外部访问数据库，可以自行在 `halodb` 服务中添加端口映射，PostgreSQL 的端口为 `5432`。
-       :::
+           halodb:
+             image: mysql:8.1.0
+             restart: on-failure:3
+             networks:
+               halo_network:
+             command: 
+               - --default-authentication-plugin=caching_sha2_password
+               - --character-set-server=utf8mb4
+               - --collation-server=utf8mb4_general_ci
+               - --explicit_defaults_for_timestamp=true
+             volumes:
+               - ./mysql:/var/lib/mysql
+               - ./mysqlBackup:/data/mysqlBackup
+             healthcheck:
+               test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "--silent"]
+               interval: 3s
+               retries: 5
+               start_period: 30s
+             environment:
+               # 请修改此密码，并对应修改上方 Halo 服务的 SPRING_R2DBC_PASSWORD 变量值
+               - MYSQL_ROOT_PASSWORD=o#DwN&JSa56
+               - MYSQL_DATABASE=halo
 
-    2. 创建 Halo + MySQL 的实例：
+         networks:
+           halo_network:
+         ```
 
-       ```yaml {23-29,51} title="~/halo/docker-compose.yaml"
-       version: "3"
+        :::info
+        此示例的 MySQL 数据库容器默认没有设置端口映射，如果需要在容器外部访问数据库，可以自行在 `halodb` 服务中添加端口映射，MySQL 的端口为 `3306`。
+        :::
+    </TabItem>
+    <TabItem value="halo-h2" label="Halo + H2">
+        :::warning
+        不推荐在生产环境使用默认的 H2 数据库，这可能因为操作不当导致数据文件损坏。如果因为某些原因（如内存不足以运行独立数据库）必须要使用，建议按时[备份数据](../../user-guide/backup.md)。
+        :::
 
-       services:
-         halo:
-           image: registry.fit2cloud.com/halo/halo:2.18
-           restart: on-failure:3
-           depends_on:
-             halodb:
-               condition: service_healthy
-           networks:
-             halo_network:
-           volumes:
-             - ./halo2:/root/.halo2
-           ports:
-             - "8090:8090"
-           healthcheck:
-             test: ["CMD", "curl", "-f", "http://localhost:8090/actuator/health/readiness"]
-             interval: 30s
-             timeout: 5s
-             retries: 5
-             start_period: 30s
-           command:
-             - --spring.r2dbc.url=r2dbc:pool:mysql://halodb:3306/halo
-             - --spring.r2dbc.username=root
-             # MySQL 的密码，请保证与下方 MYSQL_ROOT_PASSWORD 的变量值一致。
-             - --spring.r2dbc.password=o#DwN&JSa56
-             - --spring.sql.init.platform=mysql
-             # 外部访问地址，请根据实际需要修改
-             - --halo.external-url=http://localhost:8090/
+        ```yaml {19-24} title="~/halo/docker-compose.yaml"
+        version: "3"
 
-         halodb:
-           image: mysql:8.1.0
-           restart: on-failure:3
-           networks:
-             halo_network:
-           command: 
-             - --default-authentication-plugin=caching_sha2_password
-             - --character-set-server=utf8mb4
-             - --collation-server=utf8mb4_general_ci
-             - --explicit_defaults_for_timestamp=true
-           volumes:
-             - ./mysql:/var/lib/mysql
-             - ./mysqlBackup:/data/mysqlBackup
-           healthcheck:
-             test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "--silent"]
-             interval: 3s
-             retries: 5
-             start_period: 30s
-           environment:
-             # 请修改此密码，并对应修改上方 Halo 服务的 SPRING_R2DBC_PASSWORD 变量值
-             - MYSQL_ROOT_PASSWORD=o#DwN&JSa56
-             - MYSQL_DATABASE=halo
+        services:
+          halo:
+            image: registry.fit2cloud.com/halo/halo:2.18
+            restart: on-failure:3
+            volumes:
+              - ./halo2:/root/.halo2
+            ports:
+              - "8090:8090"
+            healthcheck:
+              test: ["CMD", "curl", "-f", "http://localhost:8090/actuator/health/readiness"]
+              interval: 30s
+              timeout: 5s
+              retries: 5
+              start_period: 30s          
+            command:
+              # 外部访问地址，请根据实际需要修改
+              - --halo.external-url=http://localhost:8090/
+        ```
+    </TabItem>
+    <TabItem value="external-db" label="使用外部数据库">
+        ```yaml {7,12-20} title="~/halo/docker-compose.yaml"
+        version: "3"
 
-       networks:
-         halo_network:
-       ```
+        services:
+          halo:
+            image: registry.fit2cloud.com/halo/halo:2.18
+            restart: on-failure:3
+            network_mode: "host"
+            volumes:
+              - ./halo2:/root/.halo2
+            command:
+              # 修改为自己已有的 MySQL 配置
+              - --spring.r2dbc.url=r2dbc:pool:mysql://localhost:3306/halo
+              - --spring.r2dbc.username=root
+              - --spring.r2dbc.password=
+              - --spring.sql.init.platform=mysql
+              # 外部访问地址，请根据实际需要修改
+              - --halo.external-url=http://localhost:8090/
+              # 端口号 默认8090
+              - --server.port=8090
+        ```
+    </TabItem>
+   </Tabs>
 
-       :::info
-       此示例的 MySQL 数据库容器默认没有设置端口映射，如果需要在容器外部访问数据库，可以自行在 `halodb` 服务中添加端口映射，MySQL 的端口为 `3306`。
-       :::
+   运行参数详解：
 
-    3. 仅创建 Halo 实例（使用默认的 H2 数据库）：
-
-       :::warning
-       不推荐在生产环境使用默认的 H2 数据库，这可能因为操作不当导致数据文件损坏。如果因为某些原因（如内存不足以运行独立数据库）必须要使用，建议按时[备份数据](../../user-guide/backup.md)。
-       :::
-
-       ```yaml {19-24} title="~/halo/docker-compose.yaml"
-       version: "3"
-
-       services:
-         halo:
-           image: registry.fit2cloud.com/halo/halo:2.18
-           restart: on-failure:3
-           volumes:
-             - ./halo2:/root/.halo2
-           ports:
-             - "8090:8090"
-           healthcheck:
-             test: ["CMD", "curl", "-f", "http://localhost:8090/actuator/health/readiness"]
-             interval: 30s
-             timeout: 5s
-             retries: 5
-             start_period: 30s          
-           command:
-             # 外部访问地址，请根据实际需要修改
-             - --halo.external-url=http://localhost:8090/
-       ```
-
-    4. 仅创建 Halo 实例（使用已有外部数据库，MySQL 为例）：
-
-       ```yaml {7,12-20} title="~/halo/docker-compose.yaml"
-       version: "3"
-
-       services:
-         halo:
-           image: registry.fit2cloud.com/halo/halo:2.18
-           restart: on-failure:3
-           network_mode: "host"
-           volumes:
-             - ./halo2:/root/.halo2
-           command:
-             # 修改为自己已有的 MySQL 配置
-             - --spring.r2dbc.url=r2dbc:pool:mysql://localhost:3306/halo
-             - --spring.r2dbc.username=root
-             - --spring.r2dbc.password=
-             - --spring.sql.init.platform=mysql
-             # 外部访问地址，请根据实际需要修改
-             - --halo.external-url=http://localhost:8090/
-             # 端口号 默认8090
-             - --server.port=8090
-       ```
-
-      运行参数详解：
-
-      <DockerArgs />
+   <DockerArgs />
 
 3. 启动 Halo 服务
 

--- a/versioned_docs/version-2.18/getting-started/install/slots/_docker-args.md
+++ b/versioned_docs/version-2.18/getting-started/install/slots/_docker-args.md
@@ -3,7 +3,7 @@
 | `spring.r2dbc.url`                             | 数据库连接地址，详细可查阅下方的 `数据库配置`                                                                                                                                                                         |
 | `spring.r2dbc.username`                        | 数据库用户名                                                                                                                                                                                                          |
 | `spring.r2dbc.password`                        | 数据库密码                                                                                                                                                                                                            |
-| `spring.sql.init.platform`                     | 数据库平台名称，支持 `postgresql`、`mysql`、`h2`                                                                                                                                                                      |
+| `spring.sql.init.platform`                     | 数据库平台名称，支持 `postgresql`、`mysql`、`mariadb`、`h2`                                                                                                                                                                      |
 | `halo.external-url`                            | 外部访问链接，如果需要在公网访问，需要配置为实际访问地址                                                                                                                                                              |
 
 数据库配置：


### PR DESCRIPTION
优化 Docker Compose 部署文档的篇幅，使用选项卡展示不同的配置示例。

<img width="1030" alt="image" src="https://github.com/user-attachments/assets/47bce5f8-4e01-4a32-b78a-38dc8d35b6ff">

/kind documentation

```release-note
None
```