### PR TITLE
Update jar-file.md

### DIFF
--- a/docs/getting-started/install/jar-file.md
+++ b/docs/getting-started/install/jar-file.md
@@ -141,7 +141,7 @@ title: 使用 JAR 文件部署
 6. 测试运行 Halo
 
    ```bash
-   cd ~/app && java -jar halo.jar --spring.config.additional-location=optional:file:$HOME/.halo2/
+   cd ~/app && java -jar halo.jar --spring.config.additional-location=optional:file:$HOME/.halo2/application.yaml
    ```
 
 7. 如果没有观察到异常日志，即可尝试访问 Halo
@@ -188,7 +188,7 @@ title: 使用 JAR 文件部署
    [Service]
    Type=simple
    User=USER
-   ExecStart=/usr/bin/java -server -Xms256m -Xmx256m -jar JAR_PATH --spring.config.additional-location=optional:file:/home/halo/.halo2/
+   ExecStart=/usr/bin/java -server -Xms256m -Xmx256m -jar JAR_PATH --spring.config.additional-location=optional:file:/home/halo/.halo2/application.yaml
    ExecStop=/bin/kill -s QUIT $MAINPID
    Restart=always
    StandOutput=syslog


### PR DESCRIPTION
--spring.config.additional-location=optional:file:后如果只有一个application.yaml的话，最好跟绝对路径。

在我测试时使用file:/halo/路径会导致配置文件无法被识别，file:/halo/application.yaml则没有任何问题。

当配置文件未被识别（即没有配置文件时），默认路径为$HOME/.halo2/，故个人猜测遵循此文档进行配置时配置文件也没有生效。看似生效只是因为jar文件里写死了存储路径。