### PR TITLE
fix: show correct last update time/author

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@v3
         with:
@@ -38,6 +40,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@v3
         with:


### PR DESCRIPTION
### What this PR does？
此 PR 解决了每个页面的“最后更新时间”和作者信息都相同，并且被设置为最近一次提交的时间和作者的问题。
它修改了用于发布站点的 docs 工作流中的 git fetch 深度，具体细节请参见此讨论： https://github.com/facebook/docusaurus/issues/2798#issuecomment-636602951

```release-note
None
```