### PR TITLE
chore: bump docusaurus to 3.6.2

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  presets: [require.resolve('@docusaurus/core/lib/babel/preset')],
-};

--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
     ]
   },
   "dependencies": {
-    "@docusaurus/core": "3.5.2-canary-6127",
-    "@docusaurus/faster": "3.5.2-canary-6127",
-    "@docusaurus/plugin-client-redirects": "3.5.2-canary-6127",
-    "@docusaurus/preset-classic": "3.5.2-canary-6127",
-    "@docusaurus/theme-classic": "3.5.2-canary-6127",
-    "@docusaurus/theme-common": "3.5.2-canary-6127",
-    "@docusaurus/theme-mermaid": "3.5.2-canary-6127",
+    "@docusaurus/core": "3.6.2",
+    "@docusaurus/faster": "3.6.2",
+    "@docusaurus/plugin-client-redirects": "3.6.2",
+    "@docusaurus/preset-classic": "3.6.2",
+    "@docusaurus/theme-classic": "3.6.2",
+    "@docusaurus/theme-common": "3.6.2",
+    "@docusaurus/theme-mermaid": "3.6.2",
     "@mdx-js/react": "^3.0.0",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.2.1",
@@ -48,7 +48,7 @@
     "url-loader": "^4.1.1"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.5.2-canary-6127",
+    "@docusaurus/module-type-aliases": "3.6.2",
     "husky": "^7.0.4",
     "markdownlint": "^0.25.1",
     "markdownlint-cli2": "^0.4.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,26 +9,26 @@ importers:
   .:
     dependencies:
       '@docusaurus/core':
-        specifier: 3.5.2-canary-6127
-        version: 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+        specifier: 3.6.2
+        version: 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       '@docusaurus/faster':
-        specifier: 3.5.2-canary-6127
-        version: 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        specifier: 3.6.2
+        version: 3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@docusaurus/plugin-client-redirects':
-        specifier: 3.5.2-canary-6127
-        version: 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+        specifier: 3.6.2
+        version: 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       '@docusaurus/preset-classic':
-        specifier: 3.5.2-canary-6127
-        version: 3.5.2-canary-6127(@algolia/client-search@4.24.0)(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(@types/react@18.3.12)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.1)(typescript@5.6.3)
+        specifier: 3.6.2
+        version: 3.6.2(@algolia/client-search@4.24.0)(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(@types/react@18.3.12)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.1)(typescript@5.6.3)
       '@docusaurus/theme-classic':
-        specifier: 3.5.2-canary-6127
-        version: 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@rspack/core@1.0.14)(@swc/core@1.7.42)(@types/react@18.3.12)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+        specifier: 3.6.2
+        version: 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@rspack/core@1.1.2)(@swc/core@1.7.42)(@types/react@18.3.12)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       '@docusaurus/theme-common':
-        specifier: 3.5.2-canary-6127
-        version: 3.5.2-canary-6127(@docusaurus/plugin-content-docs@3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+        specifier: 3.6.2
+        version: 3.6.2(@docusaurus/plugin-content-docs@3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       '@docusaurus/theme-mermaid':
-        specifier: 3.5.2-canary-6127
-        version: 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/plugin-content-docs@3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+        specifier: 3.6.2
+        version: 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/plugin-content-docs@3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       '@mdx-js/react':
         specifier: ^3.0.0
         version: 3.1.0(@types/react@18.3.12)(react@18.3.1)
@@ -40,7 +40,7 @@ importers:
         version: 1.2.1
       docusaurus-plugin-image-zoom:
         specifier: ^1.0.1
-        version: 1.0.1(@docusaurus/theme-classic@3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@rspack/core@1.0.14)(@swc/core@1.7.42)(@types/react@18.3.12)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))
+        version: 1.0.1(@docusaurus/theme-classic@3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@rspack/core@1.1.2)(@swc/core@1.7.42)(@types/react@18.3.12)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))
       file-loader:
         specifier: ^6.2.0
         version: 6.2.0(webpack@5.95.0(@swc/core@1.7.42))
@@ -64,8 +64,8 @@ importers:
         version: 4.1.1(file-loader@6.2.0(webpack@5.95.0(@swc/core@1.7.42)))(webpack@5.95.0(@swc/core@1.7.42))
     devDependencies:
       '@docusaurus/module-type-aliases':
-        specifier: 3.5.2-canary-6127
-        version: 3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 3.6.2
+        version: 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       husky:
         specifier: ^7.0.4
         version: 7.0.4
@@ -740,6 +740,258 @@ packages:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
+  '@csstools/cascade-layer-name-parser@2.0.4':
+    resolution: {integrity: sha512-7DFHlPuIxviKYZrOiwVU/PiHLm3lLUR23OMuEEtfEOQTOp9hzQ2JjdY6X5H18RVuUPJqSCI+qNnD5iOLMVE0bA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.4
+      '@csstools/css-tokenizer': ^3.0.3
+
+  '@csstools/color-helpers@5.0.1':
+    resolution: {integrity: sha512-MKtmkA0BX87PKaO1NFRTFH+UnkgnmySQOvNxJubsadusqPEC2aJ9MOQiMceZJJ6oitUl/i0L6u0M1IrmAOmgBA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.0':
+    resolution: {integrity: sha512-X69PmFOrjTZfN5ijxtI8hZ9kRADFSLrmmQ6hgDJ272Il049WGKpDY64KhrFm/7rbWve0z81QepawzjkKlqkNGw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.4
+      '@csstools/css-tokenizer': ^3.0.3
+
+  '@csstools/css-color-parser@3.0.6':
+    resolution: {integrity: sha512-S/IjXqTHdpI4EtzGoNCHfqraXF37x12ZZHA1Lk7zoT5pm2lMjFuqhX/89L7dqX4CcMacKK+6ZCs5TmEGb/+wKw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.4
+      '@csstools/css-tokenizer': ^3.0.3
+
+  '@csstools/css-parser-algorithms@3.0.4':
+    resolution: {integrity: sha512-Up7rBoV77rv29d3uKHUIVubz1BTcgyUK72IvCQAbfbMv584xHcGKCKbWh7i8hPrRJ7qU4Y8IO3IY9m+iTB7P3A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.3
+
+  '@csstools/css-tokenizer@3.0.3':
+    resolution: {integrity: sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==}
+    engines: {node: '>=18'}
+
+  '@csstools/media-query-list-parser@4.0.2':
+    resolution: {integrity: sha512-EUos465uvVvMJehckATTlNqGj4UJWkTmdWuDMjqvSUkjGpmOyFZBVwb4knxCm/k2GMTXY+c/5RkdndzFYWeX5A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.4
+      '@csstools/css-tokenizer': ^3.0.3
+
+  '@csstools/postcss-cascade-layers@5.0.1':
+    resolution: {integrity: sha512-XOfhI7GShVcKiKwmPAnWSqd2tBR0uxt+runAxttbSp/LY2U16yAVPmAf7e9q4JJ0d+xMNmpwNDLBXnmRCl3HMQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-color-function@4.0.6':
+    resolution: {integrity: sha512-EcvXfC60cTIumzpsxWuvVjb7rsJEHPvqn3jeMEBUaE3JSc4FRuP7mEQ+1eicxWmIrs3FtzMH9gR3sgA5TH+ebQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-color-mix-function@3.0.6':
+    resolution: {integrity: sha512-jVKdJn4+JkASYGhyPO+Wa5WXSx1+oUgaXb3JsjJn/BlrtFh5zjocCY7pwWi0nuP24V1fY7glQsxEYcYNy0dMFg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-content-alt-text@2.0.4':
+    resolution: {integrity: sha512-YItlZUOuZJCBlRaCf8Aucc1lgN41qYGALMly0qQllrxYJhiyzlI6RxOTMUvtWk+KhS8GphMDsDhKQ7KTPfEMSw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-exponential-functions@2.0.5':
+    resolution: {integrity: sha512-mi8R6dVfA2nDoKM3wcEi64I8vOYEgQVtVKCfmLHXupeLpACfGAided5ddMt5f+CnEodNu4DifuVwb0I6fQDGGQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-font-format-keywords@4.0.0':
+    resolution: {integrity: sha512-usBzw9aCRDvchpok6C+4TXC57btc4bJtmKQWOHQxOVKen1ZfVqBUuCZ/wuqdX5GHsD0NRSr9XTP+5ID1ZZQBXw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-gamut-mapping@2.0.6':
+    resolution: {integrity: sha512-0ke7fmXfc8H+kysZz246yjirAH6JFhyX9GTlyRnM0exHO80XcA9zeJpy5pOp5zo/AZiC/q5Pf+Hw7Pd6/uAoYA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-gradients-interpolation-method@5.0.6':
+    resolution: {integrity: sha512-Itrbx6SLUzsZ6Mz3VuOlxhbfuyLTogG5DwEF1V8dAi24iMuvQPIHd7Ti+pNDp7j6WixndJGZaoNR0f9VSzwuTg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-hwb-function@4.0.6':
+    resolution: {integrity: sha512-927Pqy3a1uBP7U8sTfaNdZVB0mNXzIrJO/GZ8us9219q9n06gOqCdfZ0E6d1P66Fm0fYHvxfDbfcUuwAn5UwhQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-ic-unit@4.0.0':
+    resolution: {integrity: sha512-9QT5TDGgx7wD3EEMN3BSUG6ckb6Eh5gSPT5kZoVtUuAonfPmLDJyPhqR4ntPpMYhUKAMVKAg3I/AgzqHMSeLhA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-initial@2.0.0':
+    resolution: {integrity: sha512-dv2lNUKR+JV+OOhZm9paWzYBXOCi+rJPqJ2cJuhh9xd8USVrd0cBEPczla81HNOyThMQWeCcdln3gZkQV2kYxA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-is-pseudo-class@5.0.1':
+    resolution: {integrity: sha512-JLp3POui4S1auhDR0n8wHd/zTOWmMsmK3nQd3hhL6FhWPaox5W7j1se6zXOG/aP07wV2ww0lxbKYGwbBszOtfQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-light-dark-function@2.0.7':
+    resolution: {integrity: sha512-ZZ0rwlanYKOHekyIPaU+sVm3BEHCe+Ha0/px+bmHe62n0Uc1lL34vbwrLYn6ote8PHlsqzKeTQdIejQCJ05tfw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-logical-float-and-clear@3.0.0':
+    resolution: {integrity: sha512-SEmaHMszwakI2rqKRJgE+8rpotFfne1ZS6bZqBoQIicFyV+xT1UF42eORPxJkVJVrH9C0ctUgwMSn3BLOIZldQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-logical-overflow@2.0.0':
+    resolution: {integrity: sha512-spzR1MInxPuXKEX2csMamshR4LRaSZ3UXVaRGjeQxl70ySxOhMpP2252RAFsg8QyyBXBzuVOOdx1+bVO5bPIzA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-logical-overscroll-behavior@2.0.0':
+    resolution: {integrity: sha512-e/webMjoGOSYfqLunyzByZj5KKe5oyVg/YSbie99VEaSDE2kimFm0q1f6t/6Jo+VVCQ/jbe2Xy+uX+C4xzWs4w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-logical-resize@3.0.0':
+    resolution: {integrity: sha512-DFbHQOFW/+I+MY4Ycd/QN6Dg4Hcbb50elIJCfnwkRTCX05G11SwViI5BbBlg9iHRl4ytB7pmY5ieAFk3ws7yyg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-logical-viewport-units@3.0.3':
+    resolution: {integrity: sha512-OC1IlG/yoGJdi0Y+7duz/kU/beCwO+Gua01sD6GtOtLi7ByQUpcIqs7UE/xuRPay4cHgOMatWdnDdsIDjnWpPw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-media-minmax@2.0.5':
+    resolution: {integrity: sha512-sdh5i5GToZOIAiwhdntRWv77QDtsxP2r2gXW/WbLSCoLr00KTq/yiF1qlQ5XX2+lmiFa8rATKMcbwl3oXDMNew==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-media-queries-aspect-ratio-number-values@3.0.4':
+    resolution: {integrity: sha512-AnGjVslHMm5xw9keusQYvjVWvuS7KWK+OJagaG0+m9QnIjZsrysD2kJP/tr/UJIyYtMCtu8OkUd+Rajb4DqtIQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-nested-calc@4.0.0':
+    resolution: {integrity: sha512-jMYDdqrQQxE7k9+KjstC3NbsmC063n1FTPLCgCRS2/qHUbHM0mNy9pIn4QIiQGs9I/Bg98vMqw7mJXBxa0N88A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-normalize-display-values@4.0.0':
+    resolution: {integrity: sha512-HlEoG0IDRoHXzXnkV4in47dzsxdsjdz6+j7MLjaACABX2NfvjFS6XVAnpaDyGesz9gK2SC7MbNwdCHusObKJ9Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-oklab-function@4.0.6':
+    resolution: {integrity: sha512-Hptoa0uX+XsNacFBCIQKTUBrFKDiplHan42X73EklG6XmQLG7/aIvxoNhvZ7PvOWMt67Pw3bIlUY2nD6p5vL8A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-progressive-custom-properties@4.0.0':
+    resolution: {integrity: sha512-XQPtROaQjomnvLUSy/bALTR5VCtTVUFwYs1SblvYgLSeTo2a/bMNwUwo2piXw5rTv/FEYiy5yPSXBqg9OKUx7Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-random-function@1.0.1':
+    resolution: {integrity: sha512-Ab/tF8/RXktQlFwVhiC70UNfpFQRhtE5fQQoP2pO+KCPGLsLdWFiOuHgSRtBOqEshCVAzR4H6o38nhvRZq8deA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-relative-color-syntax@3.0.6':
+    resolution: {integrity: sha512-yxP618Xb+ji1I624jILaYM62uEmZcmbdmFoZHoaThw896sq0vU39kqTTF+ZNic9XyPtPMvq0vyvbgmHaszq8xg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-scope-pseudo-class@4.0.1':
+    resolution: {integrity: sha512-IMi9FwtH6LMNuLea1bjVMQAsUhFxJnyLSgOp/cpv5hrzWmrUYU5fm0EguNDIIOHUqzXode8F/1qkC/tEo/qN8Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-sign-functions@1.1.0':
+    resolution: {integrity: sha512-SLcc20Nujx/kqbSwDmj6oaXgpy3UjFhBy1sfcqPgDkHfOIfUtUVH7OXO+j7BU4v/At5s61N5ZX6shvgPwluhsA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-stepped-value-functions@4.0.5':
+    resolution: {integrity: sha512-G6SJ6hZJkhxo6UZojVlLo14MohH4J5J7z8CRBrxxUYy9JuZiIqUo5TBYyDGcE0PLdzpg63a7mHSJz3VD+gMwqw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-text-decoration-shorthand@4.0.1':
+    resolution: {integrity: sha512-xPZIikbx6jyzWvhms27uugIc0I4ykH4keRvoa3rxX5K7lEhkbd54rjj/dv60qOCTisoS+3bmwJTeyV1VNBrXaw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-trigonometric-functions@4.0.5':
+    resolution: {integrity: sha512-/YQThYkt5MLvAmVu7zxjhceCYlKrYddK6LEmK5I4ojlS6BmO9u2yO4+xjXzu2+NPYmHSTtP4NFSamBCMmJ1NJA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-unset-value@4.0.0':
+    resolution: {integrity: sha512-cBz3tOCI5Fw6NIFEwU3RiwK6mn3nKegjpJuzCndoGq3BZPkUjnsq7uQmIeMNeMbMk7YD2MfKcgCpZwX5jyXqCA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/selector-resolve-nested@3.0.0':
+    resolution: {integrity: sha512-ZoK24Yku6VJU1gS79a5PFmC8yn3wIapiKmPgun0hZgEI5AOqgH2kiPRsPz1qkGv4HL+wuDLH83yQyk6inMYrJQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss-selector-parser: ^7.0.0
+
+  '@csstools/selector-specificity@5.0.0':
+    resolution: {integrity: sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss-selector-parser: ^7.0.0
+
+  '@csstools/utilities@2.0.0':
+    resolution: {integrity: sha512-5VdOr0Z71u+Yp3ozOx8T11N703wIFGVRgOWbOZMKgglPJsWA54MRIoMNVMa7shUToIhx5J8vX4sOZgD2XiihiQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
   '@discoveryjs/json-ext@0.5.7':
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
@@ -764,21 +1016,21 @@ packages:
       search-insights:
         optional: true
 
-  '@docusaurus/babel@3.5.2-canary-6127':
-    resolution: {integrity: sha512-k1l165Nc99i1wnRoMNldF6RCHufgm5N+H6Fr/I1I91Q0Rk2iGXvlyKr0fstxMWcZUeK9QU202JbYMt4wC4bK/w==}
+  '@docusaurus/babel@3.6.2':
+    resolution: {integrity: sha512-v8N8TWGXDsb5sxQC3Rcqb1CZr0LlU1OgqqVBUchN6cpIUr7EJuVJs5eHcIu5Ag8mwO/hWN3f7FE9uaHTMapAbg==}
     engines: {node: '>=18.0'}
 
-  '@docusaurus/bundler@3.5.2-canary-6127':
-    resolution: {integrity: sha512-q1KqaU9yfZsin6Fgml+sO9MyYML7h5W83d3Up8QlvlAhbquIPnsRFH7waXXwehx5geEs443j5rp46s2gnztuXg==}
+  '@docusaurus/bundler@3.6.2':
+    resolution: {integrity: sha512-YkEifEVs4lV931SrHBB4n6WqRowMw+aM/QPH3z8aU+5t1dWa+1p2OPqARS+tSbh3la9ns+L1zIfSbd8RHi2/PQ==}
     engines: {node: '>=18.0'}
     peerDependencies:
-      '@docusaurus/faster': 3.5.2
+      '@docusaurus/faster': '*'
     peerDependenciesMeta:
       '@docusaurus/faster':
         optional: true
 
-  '@docusaurus/core@3.5.2-canary-6127':
-    resolution: {integrity: sha512-Y6J0DCmsK0UkVSklsHZ+5PDm3S5gR2WsiFSMBOKyn1er/JxLXa61eTQmuF6IiCeL3qUriyeP3bHfjLummv54fA==}
+  '@docusaurus/core@3.6.2':
+    resolution: {integrity: sha512-irMts/mGLZv8dWcy0WUtbY/U6b5qIfHgQd1/kXMyAxUJo99fL0wFSqhMI+tcxjk0HYy427MXerLMqFJj+Arg1w==}
     engines: {node: '>=18.0'}
     hasBin: true
     peerDependencies:
@@ -786,99 +1038,99 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
-  '@docusaurus/cssnano-preset@3.5.2-canary-6127':
-    resolution: {integrity: sha512-XF7L6iimSpR7KxIX1PUFo4pM7mi6M7M2cEYXj/RmBHom6kySwS0P4u+T2Z4Gt7NMCq7G5cGQPU4jW9WwmJ8IkA==}
+  '@docusaurus/cssnano-preset@3.6.2':
+    resolution: {integrity: sha512-mBkVa4QMHRwCFCVLYdBlOZuAT1iVVsS7GGSgliSVAeTOagP/AbtlBsCVrBs+keEuDuRF1w/6QEcqDoZe9fa5pw==}
     engines: {node: '>=18.0'}
 
-  '@docusaurus/faster@3.5.2-canary-6127':
-    resolution: {integrity: sha512-9r/NGkSt90qaRT8DS2iD7tko15tZYgimGpAYbmRVhec6jfbwG/uW0hfMnupxpZeC8IdqGPBZCSVoDIRToo+hRw==}
+  '@docusaurus/faster@3.6.2':
+    resolution: {integrity: sha512-r+soceklUKPaP6KRh5JXsN/Y6WBAqbsi6It/TuLppHNpSwZF/kZzSCvjG+XigIr92G2bdHUDpPocFOfNrANv0w==}
     engines: {node: '>=18.0'}
     peerDependencies:
       '@docusaurus/types': '*'
 
-  '@docusaurus/logger@3.5.2-canary-6127':
-    resolution: {integrity: sha512-vsCNxM1lZ3RoNcfQpWULHfAtEvQKoRCa+/LIF0JAyR8r8mRSOf71rohT5FYwcYFqxjTFGC6oyI4a84XOtYOALA==}
+  '@docusaurus/logger@3.6.2':
+    resolution: {integrity: sha512-1p4IQhhgLyIfsey4UAdAIW69aUE1Ei6O91Nsw30ryZeDWSG5dh4o3zaRGOLxfAX69Ac/yDm6YCwJOafUxL6Vxg==}
     engines: {node: '>=18.0'}
 
-  '@docusaurus/mdx-loader@3.5.2-canary-6127':
-    resolution: {integrity: sha512-AlAKWOU98jmSlpvQQw+O1AUy7k3NVffTTrUo34e2h4NFKk9HiEhcOiroKKtjLTmfUA5nV6m3ieCEZ+vf1AR97w==}
+  '@docusaurus/mdx-loader@3.6.2':
+    resolution: {integrity: sha512-7fbRmNgF3CR96Ja82Ya0/Cdu1OL9UJ/22llNMY8lr5gAbw718Y5ryXMVRIYn0JNLTiSxzgtvW4DIsUWEB8NMpw==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
 
-  '@docusaurus/module-type-aliases@3.5.2-canary-6127':
-    resolution: {integrity: sha512-qmG6M4vGeeKoeYTcNobYQMsLmwLLXEUM1TWkXQHQbZQ/3CZNBN/wTDSGWFYTAJgUzMJ4xareXHrkxyUGclmbSg==}
+  '@docusaurus/module-type-aliases@3.6.2':
+    resolution: {integrity: sha512-NrJkL2rLTCjHtWOqUvWzwqvJrsKLj0gVJeV6q5yeKdKKgItietcTf2fTRkM9LHKSUN8CBDXxwHABeQvTahvmXQ==}
     peerDependencies:
       react: '*'
       react-dom: '*'
 
-  '@docusaurus/plugin-client-redirects@3.5.2-canary-6127':
-    resolution: {integrity: sha512-MBEV8bo6AQO7EsjEniDQ/c1H1Jq33hawm0aYXENQVySB2ZHrew6uFn3gGs+QhXOopVRxnG5WOOUWbKdagV1t6g==}
+  '@docusaurus/plugin-client-redirects@3.6.2':
+    resolution: {integrity: sha512-rzRq20NKQZr5kgeMGt2DA993UfhXWEAiZk9j+ttikFnFpgc/EOrpDoWDukd8Xfw4ObQ2h8TexWgABStKNKCocg==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
 
-  '@docusaurus/plugin-content-blog@3.5.2-canary-6127':
-    resolution: {integrity: sha512-7sLwRa4c0thxJd9ralFddMiEq2nGxKpvK5ul01SEwH9xvWCHUBHi8ebH2y+zB4tLa/O3nryQEgWfiAQGpgEHZQ==}
+  '@docusaurus/plugin-content-blog@3.6.2':
+    resolution: {integrity: sha512-6bJxr6Or4NslEVH3BJuPH30kUWiqUjDRdGPhvxpHmt9W/RY2/6u72WICG3bW3dLFxJ/2uDLBU92lHnatpvo7Ew==}
     engines: {node: '>=18.0'}
     peerDependencies:
       '@docusaurus/plugin-content-docs': '*'
       react: ^18.0.0
       react-dom: ^18.0.0
 
-  '@docusaurus/plugin-content-docs@3.5.2-canary-6127':
-    resolution: {integrity: sha512-QfWkCvoCYhbpsZF/z0pAI55gNcQn07+HSuLpPOuQPweSwsYMKwPfKaV3S3jcJMCDr67TSqxy0oAoXW7/yv1vYw==}
+  '@docusaurus/plugin-content-docs@3.6.2':
+    resolution: {integrity: sha512-e6WW1g10RIXXLN/rrtqTi/FyJ1Hj3X9Mmgz4V11/0pDCxIGGI8m4ocbAglUlLtgvbLD5viNLefl/NwbOW3JXiQ==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
 
-  '@docusaurus/plugin-content-pages@3.5.2-canary-6127':
-    resolution: {integrity: sha512-z94MlMg4cTJgu5ApSH78/8n8uj1PNlj1luJMiIc72V/lL8kNLOB2M3l5gH5EIzLD1beoARfyfy4SkIQkkFu9xg==}
+  '@docusaurus/plugin-content-pages@3.6.2':
+    resolution: {integrity: sha512-fo4NyGkw10lYHyHaTxE6TZLYnxNtCfRHeZkNK1N9pBYqe7TT2dBUNAEeVW2U3ed9m6YuB7JKSQsa++GGmcP+6g==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
 
-  '@docusaurus/plugin-debug@3.5.2-canary-6127':
-    resolution: {integrity: sha512-9rLARJcNiaRF5pS6FY8RDlgeOQw82c6DiIrK7L5lddlIK/k2iIuBm5BD23eKwVhBZQH9IolxoHOd4cQZUMuNIQ==}
+  '@docusaurus/plugin-debug@3.6.2':
+    resolution: {integrity: sha512-T/eS3VvHElpeV5S8uwp7Si4ujEynmgFtJLvA2CSa5pzQuOF1EEghF9nekAIj0cWtDHsqNUDZNr8hK1brivFXSg==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
 
-  '@docusaurus/plugin-google-analytics@3.5.2-canary-6127':
-    resolution: {integrity: sha512-jcIIKOsJaLuDwpe96bRC+eFo0nn4CpE+BgLoAyr+PoBFoEyaXvgvg6SXQhAQLNabIgoN/k0JEMAmuH3+Knzvhw==}
+  '@docusaurus/plugin-google-analytics@3.6.2':
+    resolution: {integrity: sha512-B7ihrr3wz8e4XqW+dIAtq844u3Z83u5CeiL1xrCqzFH+vDCjUZHTamS3zKXNcgi6YVVe6hUQXPG15ltaqQaVPQ==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
 
-  '@docusaurus/plugin-google-gtag@3.5.2-canary-6127':
-    resolution: {integrity: sha512-OVurhcsDs/KNjqkJVKIo74ZX9RS7he+vYM4FBK3pAe36rrjboaD1kpqe4Zo2RW+ik4LGsuQ48zpgxjBwJqb8RQ==}
+  '@docusaurus/plugin-google-gtag@3.6.2':
+    resolution: {integrity: sha512-V8ijI6qddAAkJ0vd8sjZ7S/apRTLJn9dAwvj/rSMd93witGdKINemL+9TyfLkhcXKTxyqRT8zKdu8ewjPXqKHg==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
 
-  '@docusaurus/plugin-google-tag-manager@3.5.2-canary-6127':
-    resolution: {integrity: sha512-Y7hzyTxdFPdURPUdKwSLnkRoFLDoV61wZMNMekjKYfx1W04lPSrOqFxZ0O39ahYx7nNX2J1M9q4njmPeP6O5Zw==}
+  '@docusaurus/plugin-google-tag-manager@3.6.2':
+    resolution: {integrity: sha512-fnWQ5FdN9f8c8VTgjaQ98208Y+d/JjHhD506rWIIL9rt1cJOf29XElxvOeKpMJadfkgY5KLZSAiHkGt+4qgN4g==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
 
-  '@docusaurus/plugin-sitemap@3.5.2-canary-6127':
-    resolution: {integrity: sha512-h6asEkqMICn53LyDVR0RoPt0+IjGWVrqRZWT56Au9qrGWkMiS8Vz4EYQ6/ZlG01nA5PVzxSlZHuzDaT0o4B13Q==}
+  '@docusaurus/plugin-sitemap@3.6.2':
+    resolution: {integrity: sha512-qcAQAP1Ot0dZpeRoJ0L/Zck5FVDkll2IleVZQLzxeRVDZIw1P9/TK7/Aw1w2pmH7dmw/Cwk/cLSVRvLAmp9k7A==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
 
-  '@docusaurus/preset-classic@3.5.2-canary-6127':
-    resolution: {integrity: sha512-uGCgcBowf+HkdxhG6jYUpkoX2P15kPDYw9GblI5K72tIp3QPgGdEuyC+LUAhM8hpy5Ylz0H1Giv6hP5ydbyMSw==}
+  '@docusaurus/preset-classic@3.6.2':
+    resolution: {integrity: sha512-r2n5eHdhiNSrJGsrrYcw+WsyStmXxe0ZG3RdA9LVyK5+jBHM8blrUWJEDugnzCNbyhUzhdtcmgCC9fhdAvKuQw==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0
@@ -889,66 +1141,56 @@ packages:
     peerDependencies:
       react: '*'
 
-  '@docusaurus/theme-classic@3.5.2-canary-6127':
-    resolution: {integrity: sha512-aAdWIDNtrcASatcMbBaKooEijjpUXE4Uh+Ct+2gKqi8GFsOrXhIjUav8aSkOAAUD9WmOETOP+MqrR0a/AtI/dg==}
+  '@docusaurus/theme-classic@3.6.2':
+    resolution: {integrity: sha512-bCdOPqPNezhLx+hgNVO2Cf+8/1AHa9uHDOqTx/CKAx2I0J/jV9G+6JiMtpSRKGNfBoLT1O+56/7+WtkOf54xTw==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
 
-  '@docusaurus/theme-common@3.5.2-canary-6127':
-    resolution: {integrity: sha512-jJg8Mwzaxjy4HopydJVKBEdMf4/ArhSK6OUeRHHpBU0m8s7Fqyj1XmdfexJemy3r3dEY1RlAGASg78goljzySw==}
+  '@docusaurus/theme-common@3.6.2':
+    resolution: {integrity: sha512-lfgsL064KEHpCkgGUc0OYoUPCpYfzggp6Hof8sz59UuKiLvb/Z7raewE9/NfocrJ2HZI17rLgMX3SQlRDh/5gg==}
     engines: {node: '>=18.0'}
     peerDependencies:
       '@docusaurus/plugin-content-docs': '*'
       react: ^18.0.0
       react-dom: ^18.0.0
 
-  '@docusaurus/theme-mermaid@3.5.2-canary-6127':
-    resolution: {integrity: sha512-shNkS9laukUnM+u2jN53q3XaDGbDdC/409gwSt7LdXGmuYE+lg5Eek7Oa/W7o2z9Ld/pEoHzhBS6cJuZZEm1Kw==}
+  '@docusaurus/theme-mermaid@3.6.2':
+    resolution: {integrity: sha512-Ui+rBtqMPKj3RCOxNlY04i1tEjNg+fZg4URTvkHmYR07hcKaJw+vkw+wlaYjd0HFZk+3Er9vUAcwsCWuea4cVQ==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
 
-  '@docusaurus/theme-search-algolia@3.5.2-canary-6127':
-    resolution: {integrity: sha512-1FCTGo1nXW9S1L2UL++ljJgT2V2pVq8uEoaXkY6+khxGpbpFnXiaBk2bMFAAIlZOzfMv5E7RyK6qgmws6ZjRzQ==}
+  '@docusaurus/theme-search-algolia@3.6.2':
+    resolution: {integrity: sha512-SFLS+Rq8Cg2yepnHucA9sRpIR97yHvZWlCgMzBLunV3KHbB6hD2h5HPhFV39wYHYCjJUAOH1lX9poJ1qKYuSvg==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
 
-  '@docusaurus/theme-translations@3.5.2-canary-6127':
-    resolution: {integrity: sha512-7CgNXwvcw2GH6lB+FOfaz/kyZ3CrnCr/qYFiNbDS6RKI/psHED8IXsmrQivVaV6hWQ/V1JX0ODKd0LTVwD59KQ==}
+  '@docusaurus/theme-translations@3.6.2':
+    resolution: {integrity: sha512-LIWrYoDUsOTKmb0c7IQzawiPUTAaczBs5IOx6srxOWoTHVUMLzJCkl5Y6whfuRrnul8G05qv2vk238bN5Ko62g==}
     engines: {node: '>=18.0'}
 
-  '@docusaurus/types@3.5.2-canary-6127':
-    resolution: {integrity: sha512-Zi5YNvV/Hel8mG05vDZX8Dm4KvaMN+QIHuRuLPxDZwJqXZ314/zs5araR8JMGSgP44ovYgWoN6VkzU7ueNThrQ==}
+  '@docusaurus/types@3.6.2':
+    resolution: {integrity: sha512-117Wsk6xXrWEAsCYCXS3TGJv5tkdIZDcd7T/V0UJvKYmY0gyVPPcEQChy8yTdjbIkbB2q4fa7Jpox72Qv86mqQ==}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
 
-  '@docusaurus/utils-common@3.5.2-canary-6127':
-    resolution: {integrity: sha512-Wd53YLyLTRm9hfzwnryJQs77EY0xRGq6uisfAkZ6nccPkCNd5wZQM5QoQg6XEOlaa38G+aG2yvKRz4b8nClLxw==}
-    engines: {node: '>=18.0'}
-    peerDependencies:
-      '@docusaurus/types': '*'
-    peerDependenciesMeta:
-      '@docusaurus/types':
-        optional: true
-
-  '@docusaurus/utils-validation@3.5.2-canary-6127':
-    resolution: {integrity: sha512-FPiNF65/hre5MTQLlC/UVi9dGh2o2mq23ywYK/YSI1hlyK/7zQPUd6x9VVLEdVVxnI26tVMZAsoq5P7qywB5QA==}
+  '@docusaurus/utils-common@3.6.2':
+    resolution: {integrity: sha512-dr5wK+OyU2QAWxG7S5siD2bPgS7+ZeqWHfgLNHZ5yalaZf8TbeNNLqydfngukAY56BGZN0NbMkX6jGIr7ZF0sA==}
     engines: {node: '>=18.0'}
 
-  '@docusaurus/utils@3.5.2-canary-6127':
-    resolution: {integrity: sha512-Ag3onEQFfP3As9AOgh9AcZsagXuM3STYVCwQ0TmWaIXhEPiD8oO3MXxMp+dsOERi7AJm6sX59CJl60Db147Wnw==}
+  '@docusaurus/utils-validation@3.6.2':
+    resolution: {integrity: sha512-Y3EwblDz72KOcobb5t2zlhHSmrfE8EaHusPJ96Kx2JYtNXL2omqCoOb6FpaXWhES75wvjUpkFLYfiNqAqEov8g==}
     engines: {node: '>=18.0'}
-    peerDependencies:
-      '@docusaurus/types': '*'
-    peerDependenciesMeta:
-      '@docusaurus/types':
-        optional: true
+
+  '@docusaurus/utils@3.6.2':
+    resolution: {integrity: sha512-oxnpUcFZGE3uPCDoXr8GJriB3VWM9sFjPedFidX3Fsz87l1NZNc1wtbKPfQ7GYFDMYo2IGlAv5+47Me9RkM6lg==}
+    engines: {node: '>=18.0'}
 
   '@hapi/hoek@9.3.0':
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
@@ -1045,56 +1287,56 @@ packages:
   '@polka/url@1.0.0-next.28':
     resolution: {integrity: sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==}
 
-  '@rspack/binding-darwin-arm64@1.0.14':
-    resolution: {integrity: sha512-dHvlF6T6ctThGDIdvkSdacroA1xlCxfteuppBj8BX/UxzLPr4xsaEtNilfJmFfd2/J02UQyTQauN/9EBuA+YkA==}
+  '@rspack/binding-darwin-arm64@1.1.2':
+    resolution: {integrity: sha512-Ay4Srve6U3pDFCsmwVJ1PHHKyeURO/iNU1pjiH986Q30bHDozfHWxCjcy0BJnK4CI4HcSaMQi5YF6BMps3ayuQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@1.0.14':
-    resolution: {integrity: sha512-q4Da1Bn/4xTLhhnOkT+fjP2STsSCfp4z03/J/h8tCVG/UYz56Ud3q1UEOK33c5Fxw1C4GlhEh5yYOlSAdxFQLQ==}
+  '@rspack/binding-darwin-x64@1.1.2':
+    resolution: {integrity: sha512-s/Mepgi8SHs75QNCtnHo/ua4fAsAz3JdJ6EfdkTmODCE2GwExXy43xl0qWhlzN1FDHnRFIZ0k6tWE0K+uCbKpQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@1.0.14':
-    resolution: {integrity: sha512-JogYtL3VQS9wJ3p3FNhDqinm7avrMsdwz4erP7YCjD7idob93GYAE7dPrHUzSNVnCBYXRaHJYZHDQs7lKVcYZw==}
+  '@rspack/binding-linux-arm64-gnu@1.1.2':
+    resolution: {integrity: sha512-x2JgHIAKY9CaCt5Q0EwlomyfhLYUOJ7PRUy85axROvMAPRnyRmcDr2OYQPa4KSQ+nDvF7m5SVmchHhepaORwaw==}
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-musl@1.0.14':
-    resolution: {integrity: sha512-qgybhxI/nnoa8CUz7zKTC0Oh37NZt9uRxsSV7+ZYrfxqbrVCoNVuutPpY724uUHy1M6W34kVEm1uT1N4Ka5cZg==}
+  '@rspack/binding-linux-arm64-musl@1.1.2':
+    resolution: {integrity: sha512-kvikjjzErfJEGldJnBTRPSkXcoICaW1PUkicVZJGYcpS6AmXz9OdbHsBKhBvJFCP+BoAHRpK10L0DAydF9kSfg==}
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-gnu@1.0.14':
-    resolution: {integrity: sha512-5vzaDRw3/sGKo3ax/1cU3/cxqNjajwlt2LU288vXNe1/n8oe/pcDfYcTugpOe/A1DqzadanudJszLpFcKsaFtQ==}
+  '@rspack/binding-linux-x64-gnu@1.1.2':
+    resolution: {integrity: sha512-wg5n7qTl0NRGL+7dzrZcKObM18GKMQDL5Ke7cEWmdHooH0rlyYK6ExIqzE5u/3GJ7KYBlDj/IgAMu5KLd8Ygjw==}
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-musl@1.0.14':
-    resolution: {integrity: sha512-4U6QD9xVS1eGme52DuJr6Fg/KdcUfJ+iKwH49Up460dZ/fLvGylnVGA+V0mzPlKi8gfy7NwFuYXZdu3Pwi1YYg==}
+  '@rspack/binding-linux-x64-musl@1.1.2':
+    resolution: {integrity: sha512-1705atWiL6mo0KVRUoRcn5SFirUAJhREENzsQSucIYyHOX5bKjPDrd+7SAOSLOGc/yGJSmWZv6NzEH/WvY8TeA==}
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-win32-arm64-msvc@1.0.14':
-    resolution: {integrity: sha512-SjeYw7qqRHYZ5RPClu+ffKZsShQdU3amA1OwC3M0AS6dbfEcji8482St3Y8Z+QSzYRapCEZij9LMM/9ypEhISg==}
+  '@rspack/binding-win32-arm64-msvc@1.1.2':
+    resolution: {integrity: sha512-DL9v6PAlC0dZnAjwNpdv5JyebidIctLTRCXO6q3bVL03i0jSyX5gRnd6YM5A9176M5HLBnSJjgujqhCffeFA3g==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@1.0.14':
-    resolution: {integrity: sha512-m1gUiVyz3Z3VYIK/Ayo5CVHBjnEeRk9a+KIpKSsq1yhZItnMgjtr4bKabU9vjxalO4UoaSmVzODJI8lJBlnn5Q==}
+  '@rspack/binding-win32-ia32-msvc@1.1.2':
+    resolution: {integrity: sha512-RluX7GENVpophR5BB4v0XxqffpGpBLTJDwoQBY0LjfOTGpLv8A0zrGIOMUsJGKE10MOlNfTUQOyB+p6sxLJzcQ==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@1.0.14':
-    resolution: {integrity: sha512-Gbeg+bayMF9VP9xmlxySL/TC2XrS6/LZM/pqcNOTLHx6LMG/VXCcmKB0rOZo8MzLXEt8D/lQmQ/B6g7pSaAw0g==}
+  '@rspack/binding-win32-x64-msvc@1.1.2':
+    resolution: {integrity: sha512-fXg6y/IajuYyBy3oOsat20U+CLrDK/l4FLdg8ETfDPb5isD7jcmhyWXBeJVZVcwHT+Sj1LnLLUuhc+FGFk4aeA==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@1.0.14':
-    resolution: {integrity: sha512-0wWqFvr9hkF4LgNPgWfkTU0hhkZAMvOytoCs2p+wDX1Up1E/SgJ1U1JAsCxsl1XtUKm7mRvdWHzJmHbza3y89Q==}
+  '@rspack/binding@1.1.2':
+    resolution: {integrity: sha512-HUE7EPvrgbabbhW635wSrthidZY1Kijk6+rvmTFuxzmxsBtZNcrhUFVw7Z1fwa2fykiOhbot61EDV9X1qoIa4g==}
 
-  '@rspack/core@1.0.14':
-    resolution: {integrity: sha512-xHl23lxJZNjItGc5YuE9alz3yjb56y7EgJmAcBMPHMqgjtUt8rBu4xd/cSUjbr9/lLF9N4hdyoJiPJOFs9LEjw==}
+  '@rspack/core@1.1.2':
+    resolution: {integrity: sha512-cXYPImNpHl2nZmWcMv7WHsorkOaIZP9csPc2J8WxEJhOEotcgP33TKmRTAfJYszV4cqUuKbVjLMv0WgX1OeftQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
@@ -2229,11 +2471,23 @@ packages:
     resolution: {integrity: sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==}
     engines: {node: '>=12'}
 
+  css-blank-pseudo@7.0.1:
+    resolution: {integrity: sha512-jf+twWGDf6LDoXDUode+nc7ZlrqfaNphrBIBrcmeP3D8yw1uPaix1gCC8LUQUGQ6CycuK2opkbFFWFuq/a94ag==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
   css-declaration-sorter@7.2.0:
     resolution: {integrity: sha512-h70rUM+3PNFuaBDTLe8wF/cdWu+dOZmb7pJt8Z2sedYbAcQVQV/tEchueg3GWxwqS0cxtbxmaHEdkNACqcvsow==}
     engines: {node: ^14 || ^16 || >=18}
     peerDependencies:
       postcss: ^8.0.9
+
+  css-has-pseudo@7.0.1:
+    resolution: {integrity: sha512-EOcoyJt+OsuKfCADgLT7gADZI5jMzIe/AeI6MeAYKiFBDmNmM7kk46DtSfMj5AohUJisqVzopBpnQTlvbyaBWg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
 
   css-loader@6.11.0:
     resolution: {integrity: sha512-CTJ+AEQJjq5NzLga5pE39qdiSV56F8ywCIsqNIRF0r7BDgWsN25aazToqAFg7ZrtA/U016xudB3ffgweORxX7g==}
@@ -2272,6 +2526,12 @@ packages:
       lightningcss:
         optional: true
 
+  css-prefers-color-scheme@10.0.0:
+    resolution: {integrity: sha512-VCtXZAWivRglTZditUfB4StnsWr6YVZ2PRtuxQLKTNRdtAf8tpzaVPE9zXIF3VaSc7O70iK/j1+NXxyQCqdPjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
   css-select-base-adapter@0.1.1:
     resolution: {integrity: sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==}
 
@@ -2307,6 +2567,9 @@ packages:
   css-what@6.1.0:
     resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
     engines: {node: '>= 6'}
+
+  cssdb@8.2.1:
+    resolution: {integrity: sha512-KwEPys7lNsC8OjASI8RrmwOYYDcm0JOW9zQhcV83ejYcQkirTEyeAGui8aO2F5PiS6SLpxuTzl6qlMElIdsgIg==}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -4392,11 +4655,41 @@ packages:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
     engines: {node: '>= 0.4'}
 
+  postcss-attribute-case-insensitive@7.0.1:
+    resolution: {integrity: sha512-Uai+SupNSqzlschRyNx3kbCTWgY/2hcwtHEI/ej2LJWc9JJ77qKgGptd8DHwY1mXtZ7Aoh4z4yxfwMBue9eNgw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
   postcss-calc@9.0.1:
     resolution: {integrity: sha512-TipgjGyzP5QzEhsOZUaIkeO5mKeMFpebWzRogWG/ysonUlnHcq5aJe0jOjpfzUU8PeSaBQnrE8ehR0QA5vs8PQ==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.2.2
+
+  postcss-clamp@4.1.0:
+    resolution: {integrity: sha512-ry4b1Llo/9zz+PKC+030KUnPITTJAHeOwjfAyyB60eT0AorGLdzp52s31OsPRHRf8NchkgFoG2y6fCfn1IV1Ow==}
+    engines: {node: '>=7.6.0'}
+    peerDependencies:
+      postcss: ^8.4.6
+
+  postcss-color-functional-notation@7.0.6:
+    resolution: {integrity: sha512-wLXvm8RmLs14Z2nVpB4CWlnvaWPRcOZFltJSlcbYwSJ1EDZKsKDhPKIMecCnuU054KSmlmubkqczmm6qBPCBhA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  postcss-color-hex-alpha@10.0.0:
+    resolution: {integrity: sha512-1kervM2cnlgPs2a8Vt/Qbe5cQ++N7rkYo/2rz2BkqJZIHQwaVuJgQH38REHrAi4uM0b1fqxMkWYmese94iMp3w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  postcss-color-rebeccapurple@10.0.0:
+    resolution: {integrity: sha512-JFta737jSP+hdAIEhk1Vs0q0YF5P8fFcj+09pweS8ktuGuZ8pPlykHsk6mPxZ8awDl4TrcxUqJo9l1IhVr/OjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
 
   postcss-colormin@6.1.0:
     resolution: {integrity: sha512-x9yX7DOxeMAR+BgGVnNSAxmAj98NX/YxEMNFP+SDCEeNLb2r3i6Hh1ksMsnW8Ub5SLCpbescQqn9YEbE9554Sw==}
@@ -4409,6 +4702,30 @@ packages:
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
+
+  postcss-custom-media@11.0.5:
+    resolution: {integrity: sha512-SQHhayVNgDvSAdX9NQ/ygcDQGEY+aSF4b/96z7QUX6mqL5yl/JgG/DywcF6fW9XbnCRE+aVYk+9/nqGuzOPWeQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  postcss-custom-properties@14.0.4:
+    resolution: {integrity: sha512-QnW8FCCK6q+4ierwjnmXF9Y9KF8q0JkbgVfvQEMa93x1GT8FvOiUevWCN2YLaOWyByeDX8S6VFbZEeWoAoXs2A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  postcss-custom-selectors@8.0.4:
+    resolution: {integrity: sha512-ASOXqNvDCE0dAJ/5qixxPeL1aOVGHGW2JwSy7HyjWNbnWTQCl+fDc968HY1jCmZI0+BaYT5CxsOiUhavpG/7eg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  postcss-dir-pseudo-class@9.0.1:
+    resolution: {integrity: sha512-tRBEK0MHYvcMUrAuYMEOa0zg9APqirBcgzi6P21OhxtJyJADo/SWBwY1CAwEohQ/6HDaa9jCjLRG7K3PVQYHEA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
 
   postcss-discard-comments@6.0.2:
     resolution: {integrity: sha512-65w/uIqhSBBfQmYnG92FO1mWZjJ4GL5b8atm5Yw2UgrwD7HiNiSSNwJor1eCFGzUgYnN/iIknhNRVqjrrpuglw==}
@@ -4440,12 +4757,59 @@ packages:
     peerDependencies:
       postcss: ^8.4.31
 
+  postcss-double-position-gradients@6.0.0:
+    resolution: {integrity: sha512-JkIGah3RVbdSEIrcobqj4Gzq0h53GG4uqDPsho88SgY84WnpkTpI0k50MFK/sX7XqVisZ6OqUfFnoUO6m1WWdg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  postcss-focus-visible@10.0.1:
+    resolution: {integrity: sha512-U58wyjS/I1GZgjRok33aE8juW9qQgQUNwTSdxQGuShHzwuYdcklnvK/+qOWX1Q9kr7ysbraQ6ht6r+udansalA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  postcss-focus-within@9.0.1:
+    resolution: {integrity: sha512-fzNUyS1yOYa7mOjpci/bR+u+ESvdar6hk8XNK/TRR0fiGTp2QT5N+ducP0n3rfH/m9I7H/EQU6lsa2BrgxkEjw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  postcss-font-variant@5.0.0:
+    resolution: {integrity: sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==}
+    peerDependencies:
+      postcss: ^8.1.0
+
+  postcss-gap-properties@6.0.0:
+    resolution: {integrity: sha512-Om0WPjEwiM9Ru+VhfEDPZJAKWUd0mV1HmNXqp2C29z80aQ2uP9UVhLc7e3aYMIor/S5cVhoPgYQ7RtfeZpYTRw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  postcss-image-set-function@7.0.0:
+    resolution: {integrity: sha512-QL7W7QNlZuzOwBTeXEmbVckNt1FSmhQtbMRvGGqqU4Nf4xk6KUEQhAoWuMzwbSv5jxiRiSZ5Tv7eiDB9U87znA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  postcss-lab-function@7.0.6:
+    resolution: {integrity: sha512-HPwvsoK7C949vBZ+eMyvH2cQeMr3UREoHvbtra76/UhDuiViZH6pir+z71UaJQohd7VDSVUdR6TkWYKExEc9aQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
   postcss-loader@7.3.4:
     resolution: {integrity: sha512-iW5WTTBSC5BfsBJ9daFMPVrLT36MrNiC6fqOZTTaHjBNX6Pfd5p+hSBqe/fEeNd7pc13QiAyGt7VdGMw4eRC4A==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       postcss: ^7.0.0 || ^8.0.1
       webpack: ^5.0.0
+
+  postcss-logical@8.0.0:
+    resolution: {integrity: sha512-HpIdsdieClTjXLOyYdUPAX/XQASNIwdKt5hoZW08ZOAiI+tbV0ta1oclkpVkW5ANU+xJvk3KkA0FejkjGLXUkg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
 
   postcss-merge-idents@6.0.3:
     resolution: {integrity: sha512-1oIoAsODUs6IHQZkLQGO15uGEbK3EAl5wi9SS8hs45VgsxQfMnxvt+L+zIr7ifZFIH14cfAeVe2uCTa+SPRa3g==}
@@ -4513,6 +4877,12 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
+  postcss-nesting@13.0.1:
+    resolution: {integrity: sha512-VbqqHkOBOt4Uu3G8Dm8n6lU5+9cJFxiuty9+4rcoyRPO9zZS1JIs6td49VIoix3qYqELHlJIn46Oih9SAKo+yQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
   postcss-normalize-charset@6.0.2:
     resolution: {integrity: sha512-a8N9czmdnrjPHa3DeFlwqst5eaL5W8jYu3EBbTTkI5FHkfMhFZh1EGbku6jhHhIzTA6tquI2P42NtZ59M/H/kQ==}
     engines: {node: ^14 || ^16 || >=18.0}
@@ -4567,11 +4937,46 @@ packages:
     peerDependencies:
       postcss: ^8.4.31
 
+  postcss-opacity-percentage@3.0.0:
+    resolution: {integrity: sha512-K6HGVzyxUxd/VgZdX04DCtdwWJ4NGLG212US4/LA1TLAbHgmAsTWVR86o+gGIbFtnTkfOpb9sCRBx8K7HO66qQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
   postcss-ordered-values@6.0.2:
     resolution: {integrity: sha512-VRZSOB+JU32RsEAQrO94QPkClGPKJEL/Z9PCBImXMhIeK5KAYo6slP/hBYlLgrCjFxyqvn5VC81tycFEDBLG1Q==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
+
+  postcss-overflow-shorthand@6.0.0:
+    resolution: {integrity: sha512-BdDl/AbVkDjoTofzDQnwDdm/Ym6oS9KgmO7Gr+LHYjNWJ6ExORe4+3pcLQsLA9gIROMkiGVjjwZNoL/mpXHd5Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  postcss-page-break@3.0.4:
+    resolution: {integrity: sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==}
+    peerDependencies:
+      postcss: ^8
+
+  postcss-place@10.0.0:
+    resolution: {integrity: sha512-5EBrMzat2pPAxQNWYavwAfoKfYcTADJ8AXGVPcUZ2UkNloUTWzJQExgrzrDkh3EKzmAx1evfTAzF9I8NGcc+qw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  postcss-preset-env@10.1.1:
+    resolution: {integrity: sha512-wqqsnBFD6VIwcHHRbhjTOcOi4qRVlB26RwSr0ordPj7OubRRxdWebv/aLjKLRR8zkZrbxZyuus03nOIgC5elMQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  postcss-pseudo-class-any-link@10.0.1:
+    resolution: {integrity: sha512-3el9rXlBOqTFaMFkWDOkHUTQekFIYnaQY55Rsp8As8QQkpiSgIYEcF/6Ond93oHiDsGb4kad8zjt+NPlOC1H0Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
 
   postcss-reduce-idents@6.0.3:
     resolution: {integrity: sha512-G3yCqZDpsNPoQgbDUy3T0E6hqOQ5xigUtBQyrmq3tn2GxlyiL0yyl7H+T8ulQR6kOcHJ9t7/9H4/R2tv8tJbMA==}
@@ -4591,8 +4996,23 @@ packages:
     peerDependencies:
       postcss: ^8.4.31
 
+  postcss-replace-overflow-wrap@4.0.0:
+    resolution: {integrity: sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==}
+    peerDependencies:
+      postcss: ^8.0.3
+
+  postcss-selector-not@8.0.1:
+    resolution: {integrity: sha512-kmVy/5PYVb2UOhy0+LqUYAhKj7DUGDpSWa5LZqlkWJaaAV+dxxsOG3+St0yNLu6vsKD7Dmqx+nWQt0iil89+WA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
+    engines: {node: '>=4'}
+
+  postcss-selector-parser@7.0.0:
+    resolution: {integrity: sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==}
     engines: {node: '>=4'}
 
   postcss-sort-media-queries@5.2.0:
@@ -6611,6 +7031,258 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
+  '@csstools/cascade-layer-name-parser@2.0.4(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+
+  '@csstools/color-helpers@5.0.1': {}
+
+  '@csstools/css-calc@2.1.0(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+
+  '@csstools/css-color-parser@3.0.6(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)':
+    dependencies:
+      '@csstools/color-helpers': 5.0.1
+      '@csstools/css-calc': 2.1.0(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+
+  '@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.3
+
+  '@csstools/css-tokenizer@3.0.3': {}
+
+  '@csstools/media-query-list-parser@4.0.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+
+  '@csstools/postcss-cascade-layers@5.0.1(postcss@8.4.47)':
+    dependencies:
+      '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.0.0)
+      postcss: 8.4.47
+      postcss-selector-parser: 7.0.0
+
+  '@csstools/postcss-color-function@4.0.6(postcss@8.4.47)':
+    dependencies:
+      '@csstools/css-color-parser': 3.0.6(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.47)
+      '@csstools/utilities': 2.0.0(postcss@8.4.47)
+      postcss: 8.4.47
+
+  '@csstools/postcss-color-mix-function@3.0.6(postcss@8.4.47)':
+    dependencies:
+      '@csstools/css-color-parser': 3.0.6(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.47)
+      '@csstools/utilities': 2.0.0(postcss@8.4.47)
+      postcss: 8.4.47
+
+  '@csstools/postcss-content-alt-text@2.0.4(postcss@8.4.47)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.47)
+      '@csstools/utilities': 2.0.0(postcss@8.4.47)
+      postcss: 8.4.47
+
+  '@csstools/postcss-exponential-functions@2.0.5(postcss@8.4.47)':
+    dependencies:
+      '@csstools/css-calc': 2.1.0(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      postcss: 8.4.47
+
+  '@csstools/postcss-font-format-keywords@4.0.0(postcss@8.4.47)':
+    dependencies:
+      '@csstools/utilities': 2.0.0(postcss@8.4.47)
+      postcss: 8.4.47
+      postcss-value-parser: 4.2.0
+
+  '@csstools/postcss-gamut-mapping@2.0.6(postcss@8.4.47)':
+    dependencies:
+      '@csstools/css-color-parser': 3.0.6(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      postcss: 8.4.47
+
+  '@csstools/postcss-gradients-interpolation-method@5.0.6(postcss@8.4.47)':
+    dependencies:
+      '@csstools/css-color-parser': 3.0.6(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.47)
+      '@csstools/utilities': 2.0.0(postcss@8.4.47)
+      postcss: 8.4.47
+
+  '@csstools/postcss-hwb-function@4.0.6(postcss@8.4.47)':
+    dependencies:
+      '@csstools/css-color-parser': 3.0.6(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.47)
+      '@csstools/utilities': 2.0.0(postcss@8.4.47)
+      postcss: 8.4.47
+
+  '@csstools/postcss-ic-unit@4.0.0(postcss@8.4.47)':
+    dependencies:
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.47)
+      '@csstools/utilities': 2.0.0(postcss@8.4.47)
+      postcss: 8.4.47
+      postcss-value-parser: 4.2.0
+
+  '@csstools/postcss-initial@2.0.0(postcss@8.4.47)':
+    dependencies:
+      postcss: 8.4.47
+
+  '@csstools/postcss-is-pseudo-class@5.0.1(postcss@8.4.47)':
+    dependencies:
+      '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.0.0)
+      postcss: 8.4.47
+      postcss-selector-parser: 7.0.0
+
+  '@csstools/postcss-light-dark-function@2.0.7(postcss@8.4.47)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.47)
+      '@csstools/utilities': 2.0.0(postcss@8.4.47)
+      postcss: 8.4.47
+
+  '@csstools/postcss-logical-float-and-clear@3.0.0(postcss@8.4.47)':
+    dependencies:
+      postcss: 8.4.47
+
+  '@csstools/postcss-logical-overflow@2.0.0(postcss@8.4.47)':
+    dependencies:
+      postcss: 8.4.47
+
+  '@csstools/postcss-logical-overscroll-behavior@2.0.0(postcss@8.4.47)':
+    dependencies:
+      postcss: 8.4.47
+
+  '@csstools/postcss-logical-resize@3.0.0(postcss@8.4.47)':
+    dependencies:
+      postcss: 8.4.47
+      postcss-value-parser: 4.2.0
+
+  '@csstools/postcss-logical-viewport-units@3.0.3(postcss@8.4.47)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/utilities': 2.0.0(postcss@8.4.47)
+      postcss: 8.4.47
+
+  '@csstools/postcss-media-minmax@2.0.5(postcss@8.4.47)':
+    dependencies:
+      '@csstools/css-calc': 2.1.0(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      postcss: 8.4.47
+
+  '@csstools/postcss-media-queries-aspect-ratio-number-values@3.0.4(postcss@8.4.47)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      postcss: 8.4.47
+
+  '@csstools/postcss-nested-calc@4.0.0(postcss@8.4.47)':
+    dependencies:
+      '@csstools/utilities': 2.0.0(postcss@8.4.47)
+      postcss: 8.4.47
+      postcss-value-parser: 4.2.0
+
+  '@csstools/postcss-normalize-display-values@4.0.0(postcss@8.4.47)':
+    dependencies:
+      postcss: 8.4.47
+      postcss-value-parser: 4.2.0
+
+  '@csstools/postcss-oklab-function@4.0.6(postcss@8.4.47)':
+    dependencies:
+      '@csstools/css-color-parser': 3.0.6(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.47)
+      '@csstools/utilities': 2.0.0(postcss@8.4.47)
+      postcss: 8.4.47
+
+  '@csstools/postcss-progressive-custom-properties@4.0.0(postcss@8.4.47)':
+    dependencies:
+      postcss: 8.4.47
+      postcss-value-parser: 4.2.0
+
+  '@csstools/postcss-random-function@1.0.1(postcss@8.4.47)':
+    dependencies:
+      '@csstools/css-calc': 2.1.0(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      postcss: 8.4.47
+
+  '@csstools/postcss-relative-color-syntax@3.0.6(postcss@8.4.47)':
+    dependencies:
+      '@csstools/css-color-parser': 3.0.6(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.47)
+      '@csstools/utilities': 2.0.0(postcss@8.4.47)
+      postcss: 8.4.47
+
+  '@csstools/postcss-scope-pseudo-class@4.0.1(postcss@8.4.47)':
+    dependencies:
+      postcss: 8.4.47
+      postcss-selector-parser: 7.0.0
+
+  '@csstools/postcss-sign-functions@1.1.0(postcss@8.4.47)':
+    dependencies:
+      '@csstools/css-calc': 2.1.0(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      postcss: 8.4.47
+
+  '@csstools/postcss-stepped-value-functions@4.0.5(postcss@8.4.47)':
+    dependencies:
+      '@csstools/css-calc': 2.1.0(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      postcss: 8.4.47
+
+  '@csstools/postcss-text-decoration-shorthand@4.0.1(postcss@8.4.47)':
+    dependencies:
+      '@csstools/color-helpers': 5.0.1
+      postcss: 8.4.47
+      postcss-value-parser: 4.2.0
+
+  '@csstools/postcss-trigonometric-functions@4.0.5(postcss@8.4.47)':
+    dependencies:
+      '@csstools/css-calc': 2.1.0(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      postcss: 8.4.47
+
+  '@csstools/postcss-unset-value@4.0.0(postcss@8.4.47)':
+    dependencies:
+      postcss: 8.4.47
+
+  '@csstools/selector-resolve-nested@3.0.0(postcss-selector-parser@7.0.0)':
+    dependencies:
+      postcss-selector-parser: 7.0.0
+
+  '@csstools/selector-specificity@5.0.0(postcss-selector-parser@7.0.0)':
+    dependencies:
+      postcss-selector-parser: 7.0.0
+
+  '@csstools/utilities@2.0.0(postcss@8.4.47)':
+    dependencies:
+      postcss: 8.4.47
+
   '@discoveryjs/json-ext@0.5.7': {}
 
   '@docsearch/css@3.6.2': {}
@@ -6629,7 +7301,7 @@ snapshots:
     transitivePeerDependencies:
       - '@algolia/client-search'
 
-  '@docusaurus/babel@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)':
+  '@docusaurus/babel@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/generator': 7.26.0
@@ -6641,33 +7313,34 @@ snapshots:
       '@babel/runtime': 7.26.0
       '@babel/runtime-corejs3': 7.26.0
       '@babel/traverse': 7.25.9
-      '@docusaurus/logger': 3.5.2-canary-6127
-      '@docusaurus/utils': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)
+      '@docusaurus/logger': 3.6.2
+      '@docusaurus/utils': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       babel-plugin-dynamic-import-node: 2.3.3
       fs-extra: 11.2.0
       tslib: 2.8.0
     transitivePeerDependencies:
-      - '@docusaurus/types'
       - '@swc/core'
+      - acorn
       - esbuild
+      - react
+      - react-dom
       - supports-color
       - typescript
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/bundler@3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
+  '@docusaurus/bundler@3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
       '@babel/core': 7.26.0
-      '@docusaurus/babel': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)
-      '@docusaurus/cssnano-preset': 3.5.2-canary-6127
-      '@docusaurus/logger': 3.5.2-canary-6127
-      '@docusaurus/types': 3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)
-      autoprefixer: 10.4.20(postcss@8.4.47)
+      '@docusaurus/babel': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/cssnano-preset': 3.6.2
+      '@docusaurus/logger': 3.6.2
+      '@docusaurus/types': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       babel-loader: 9.2.1(@babel/core@7.26.0)(webpack@5.95.0(@swc/core@1.7.42))
       clean-css: 5.3.3
       copy-webpack-plugin: 11.0.0(webpack@5.95.0(@swc/core@1.7.42))
-      css-loader: 6.11.0(@rspack/core@1.0.14)(webpack@5.95.0(@swc/core@1.7.42))
+      css-loader: 6.11.0(@rspack/core@1.1.2)(webpack@5.95.0(@swc/core@1.7.42))
       css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(webpack@5.95.0(@swc/core@1.7.42))
       cssnano: 6.1.2(postcss@8.4.47)
       file-loader: 6.2.0(webpack@5.95.0(@swc/core@1.7.42))
@@ -6676,6 +7349,7 @@ snapshots:
       null-loader: 4.0.1(webpack@5.95.0(@swc/core@1.7.42))
       postcss: 8.4.47
       postcss-loader: 7.3.4(postcss@8.4.47)(typescript@5.6.3)(webpack@5.95.0(@swc/core@1.7.42))
+      postcss-preset-env: 10.1.1(postcss@8.4.47)
       react-dev-utils: 12.0.1(typescript@5.6.3)(webpack@5.95.0(@swc/core@1.7.42))
       terser-webpack-plugin: 5.3.10(@swc/core@1.7.42)(webpack@5.95.0(@swc/core@1.7.42))
       tslib: 2.8.0
@@ -6683,7 +7357,7 @@ snapshots:
       webpack: 5.95.0(@swc/core@1.7.42)
       webpackbar: 6.0.1(webpack@5.95.0(@swc/core@1.7.42))
     optionalDependencies:
-      '@docusaurus/faster': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@docusaurus/faster': 3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
     transitivePeerDependencies:
       - '@parcel/css'
       - '@rspack/core'
@@ -6702,15 +7376,15 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/core@3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
+  '@docusaurus/core@3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
-      '@docusaurus/babel': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)
-      '@docusaurus/bundler': 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/logger': 3.5.2-canary-6127
-      '@docusaurus/mdx-loader': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/utils': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)
-      '@docusaurus/utils-common': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)
+      '@docusaurus/babel': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/bundler': 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/logger': 3.6.2
+      '@docusaurus/mdx-loader': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/utils': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/utils-common': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       '@mdx-js/react': 3.1.0(@types/react@18.3.12)(react@18.3.1)
       boxen: 6.2.1
       chalk: 4.1.2
@@ -6726,7 +7400,7 @@ snapshots:
       eval: 0.1.8
       fs-extra: 11.2.0
       html-tags: 3.3.1
-      html-webpack-plugin: 5.6.3(@rspack/core@1.0.14)(webpack@5.95.0(@swc/core@1.7.42))
+      html-webpack-plugin: 5.6.3(@rspack/core@1.1.2)(webpack@5.95.0(@swc/core@1.7.42))
       leven: 3.1.0
       lodash: 4.17.21
       p-map: 4.0.0
@@ -6752,7 +7426,6 @@ snapshots:
       webpack-merge: 6.0.1
     transitivePeerDependencies:
       - '@docusaurus/faster'
-      - '@docusaurus/types'
       - '@parcel/css'
       - '@rspack/core'
       - '@swc/core'
@@ -6771,17 +7444,17 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/cssnano-preset@3.5.2-canary-6127':
+  '@docusaurus/cssnano-preset@3.6.2':
     dependencies:
       cssnano-preset-advanced: 6.1.2(postcss@8.4.47)
       postcss: 8.4.47
       postcss-sort-media-queries: 5.2.0(postcss@8.4.47)
       tslib: 2.8.0
 
-  '@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
-      '@docusaurus/types': 3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@rspack/core': 1.0.14
+      '@docusaurus/types': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@rspack/core': 1.1.2
       '@swc/core': 1.7.42
       '@swc/html': 1.7.42
       browserslist: 4.24.2
@@ -6795,16 +7468,16 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/logger@3.5.2-canary-6127':
+  '@docusaurus/logger@3.6.2':
     dependencies:
       chalk: 4.1.2
       tslib: 2.8.0
 
-  '@docusaurus/mdx-loader@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
+  '@docusaurus/mdx-loader@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
-      '@docusaurus/logger': 3.5.2-canary-6127
-      '@docusaurus/utils': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)
-      '@docusaurus/utils-validation': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)
+      '@docusaurus/logger': 3.6.2
+      '@docusaurus/utils': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/utils-validation': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       '@mdx-js/mdx': 3.1.0(acorn@8.14.0)
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
@@ -6829,7 +7502,6 @@ snapshots:
       vfile: 6.0.3
       webpack: 5.95.0(@swc/core@1.7.42)
     transitivePeerDependencies:
-      - '@docusaurus/types'
       - '@swc/core'
       - acorn
       - esbuild
@@ -6838,9 +7510,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/module-type-aliases@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@docusaurus/module-type-aliases@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@docusaurus/types': 3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/types': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/history': 4.7.11
       '@types/react': 18.3.12
       '@types/react-router-config': 5.0.11
@@ -6857,13 +7529,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-client-redirects@3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
+  '@docusaurus/plugin-client-redirects@3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
-      '@docusaurus/core': 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/logger': 3.5.2-canary-6127
-      '@docusaurus/utils': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)
-      '@docusaurus/utils-common': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)
+      '@docusaurus/core': 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/logger': 3.6.2
+      '@docusaurus/utils': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/utils-common': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       eta: 2.2.0
       fs-extra: 11.2.0
       lodash: 4.17.21
@@ -6872,7 +7544,6 @@ snapshots:
       tslib: 2.8.0
     transitivePeerDependencies:
       - '@docusaurus/faster'
-      - '@docusaurus/types'
       - '@mdx-js/react'
       - '@parcel/css'
       - '@rspack/core'
@@ -6892,17 +7563,17 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/plugin-content-docs@3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
+  '@docusaurus/plugin-content-blog@3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/plugin-content-docs@3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
-      '@docusaurus/core': 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/logger': 3.5.2-canary-6127
-      '@docusaurus/mdx-loader': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/plugin-content-docs': 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/theme-common': 3.5.2-canary-6127(@docusaurus/plugin-content-docs@3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/types': 3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)
-      '@docusaurus/utils-common': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)
+      '@docusaurus/core': 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/logger': 3.6.2
+      '@docusaurus/mdx-loader': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/plugin-content-docs': 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/theme-common': 3.6.2(@docusaurus/plugin-content-docs@3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/types': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/utils-common': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       cheerio: 1.0.0-rc.12
       feed: 4.2.2
       fs-extra: 11.2.0
@@ -6936,17 +7607,17 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
+  '@docusaurus/plugin-content-docs@3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
-      '@docusaurus/core': 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/logger': 3.5.2-canary-6127
-      '@docusaurus/mdx-loader': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/module-type-aliases': 3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/theme-common': 3.5.2-canary-6127(@docusaurus/plugin-content-docs@3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/types': 3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)
-      '@docusaurus/utils-common': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)
+      '@docusaurus/core': 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/logger': 3.6.2
+      '@docusaurus/mdx-loader': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/module-type-aliases': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/theme-common': 3.6.2(@docusaurus/plugin-content-docs@3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/types': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/utils-common': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.2.0
@@ -6978,13 +7649,13 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
+  '@docusaurus/plugin-content-pages@3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
-      '@docusaurus/core': 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/mdx-loader': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/types': 3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)
-      '@docusaurus/utils-validation': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)
+      '@docusaurus/core': 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/mdx-loader': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/types': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/utils-validation': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       fs-extra: 11.2.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -7011,11 +7682,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
+  '@docusaurus/plugin-debug@3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
-      '@docusaurus/core': 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/types': 3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)
+      '@docusaurus/core': 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/types': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       fs-extra: 11.2.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -7042,11 +7713,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
+  '@docusaurus/plugin-google-analytics@3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
-      '@docusaurus/core': 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/types': 3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)
+      '@docusaurus/core': 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/types': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.8.0
@@ -7071,11 +7742,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
+  '@docusaurus/plugin-google-gtag@3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
-      '@docusaurus/core': 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/types': 3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)
+      '@docusaurus/core': 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/types': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       '@types/gtag.js': 0.0.12
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -7101,11 +7772,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
+  '@docusaurus/plugin-google-tag-manager@3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
-      '@docusaurus/core': 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/types': 3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)
+      '@docusaurus/core': 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/types': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.8.0
@@ -7130,14 +7801,14 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
+  '@docusaurus/plugin-sitemap@3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
-      '@docusaurus/core': 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/logger': 3.5.2-canary-6127
-      '@docusaurus/types': 3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)
-      '@docusaurus/utils-common': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)
+      '@docusaurus/core': 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/logger': 3.6.2
+      '@docusaurus/types': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/utils-common': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       fs-extra: 11.2.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -7164,21 +7835,21 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.5.2-canary-6127(@algolia/client-search@4.24.0)(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(@types/react@18.3.12)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.1)(typescript@5.6.3)':
+  '@docusaurus/preset-classic@3.6.2(@algolia/client-search@4.24.0)(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(@types/react@18.3.12)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.1)(typescript@5.6.3)':
     dependencies:
-      '@docusaurus/core': 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/plugin-content-blog': 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/plugin-content-docs@3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/plugin-content-docs': 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/plugin-content-pages': 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/plugin-debug': 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/plugin-google-analytics': 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/plugin-google-gtag': 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/plugin-google-tag-manager': 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/plugin-sitemap': 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/theme-classic': 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@rspack/core@1.0.14)(@swc/core@1.7.42)(@types/react@18.3.12)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/theme-common': 3.5.2-canary-6127(@docusaurus/plugin-content-docs@3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/theme-search-algolia': 3.5.2-canary-6127(@algolia/client-search@4.24.0)(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(@types/react@18.3.12)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.1)(typescript@5.6.3)
-      '@docusaurus/types': 3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/core': 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/plugin-content-blog': 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/plugin-content-docs@3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/plugin-content-docs': 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/plugin-content-pages': 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/plugin-debug': 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/plugin-google-analytics': 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/plugin-google-gtag': 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/plugin-google-tag-manager': 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/plugin-sitemap': 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/theme-classic': 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@rspack/core@1.1.2)(@swc/core@1.7.42)(@types/react@18.3.12)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/theme-common': 3.6.2(@docusaurus/plugin-content-docs@3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/theme-search-algolia': 3.6.2(@algolia/client-search@4.24.0)(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(@types/react@18.3.12)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.1)(typescript@5.6.3)
+      '@docusaurus/types': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
@@ -7210,21 +7881,21 @@ snapshots:
       '@types/react': 18.3.12
       react: 18.3.1
 
-  '@docusaurus/theme-classic@3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@rspack/core@1.0.14)(@swc/core@1.7.42)(@types/react@18.3.12)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
+  '@docusaurus/theme-classic@3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@rspack/core@1.1.2)(@swc/core@1.7.42)(@types/react@18.3.12)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
-      '@docusaurus/core': 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/logger': 3.5.2-canary-6127
-      '@docusaurus/mdx-loader': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/module-type-aliases': 3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/plugin-content-blog': 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/plugin-content-docs@3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/plugin-content-docs': 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/plugin-content-pages': 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/theme-common': 3.5.2-canary-6127(@docusaurus/plugin-content-docs@3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/theme-translations': 3.5.2-canary-6127
-      '@docusaurus/types': 3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)
-      '@docusaurus/utils-common': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)
+      '@docusaurus/core': 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/logger': 3.6.2
+      '@docusaurus/mdx-loader': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/module-type-aliases': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/plugin-content-blog': 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/plugin-content-docs@3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/plugin-content-docs': 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/plugin-content-pages': 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/theme-common': 3.6.2(@docusaurus/plugin-content-docs@3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/theme-translations': 3.6.2
+      '@docusaurus/types': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/utils-common': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       '@mdx-js/react': 3.1.0(@types/react@18.3.12)(react@18.3.1)
       clsx: 2.1.1
       copy-text-to-clipboard: 3.2.0
@@ -7261,13 +7932,13 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-common@3.5.2-canary-6127(@docusaurus/plugin-content-docs@3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
+  '@docusaurus/theme-common@3.6.2(@docusaurus/plugin-content-docs@3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
-      '@docusaurus/mdx-loader': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/module-type-aliases': 3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/plugin-content-docs': 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/utils': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)
-      '@docusaurus/utils-common': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@docusaurus/mdx-loader': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/module-type-aliases': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/plugin-content-docs': 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/utils': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/utils-common': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/history': 4.7.11
       '@types/react': 18.3.12
       '@types/react-router-config': 5.0.11
@@ -7279,7 +7950,6 @@ snapshots:
       tslib: 2.8.0
       utility-types: 3.11.0
     transitivePeerDependencies:
-      - '@docusaurus/types'
       - '@swc/core'
       - acorn
       - esbuild
@@ -7288,13 +7958,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/theme-mermaid@3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/plugin-content-docs@3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
+  '@docusaurus/theme-mermaid@3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/plugin-content-docs@3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
-      '@docusaurus/core': 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/module-type-aliases': 3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/theme-common': 3.5.2-canary-6127(@docusaurus/plugin-content-docs@3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/types': 3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)
+      '@docusaurus/core': 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/module-type-aliases': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/theme-common': 3.6.2(@docusaurus/plugin-content-docs@3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/types': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       mermaid: 11.4.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -7321,16 +7991,16 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.5.2-canary-6127(@algolia/client-search@4.24.0)(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(@types/react@18.3.12)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.1)(typescript@5.6.3)':
+  '@docusaurus/theme-search-algolia@3.6.2(@algolia/client-search@4.24.0)(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(@types/react@18.3.12)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.1)(typescript@5.6.3)':
     dependencies:
       '@docsearch/react': 3.6.2(@algolia/client-search@4.24.0)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.1)
-      '@docusaurus/core': 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/logger': 3.5.2-canary-6127
-      '@docusaurus/plugin-content-docs': 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/theme-common': 3.5.2-canary-6127(@docusaurus/plugin-content-docs@3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.0.14)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/theme-translations': 3.5.2-canary-6127
-      '@docusaurus/utils': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)
-      '@docusaurus/utils-validation': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)
+      '@docusaurus/core': 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/logger': 3.6.2
+      '@docusaurus/plugin-content-docs': 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/theme-common': 3.6.2(@docusaurus/plugin-content-docs@3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(@rspack/core@1.1.2)(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/theme-translations': 3.6.2
+      '@docusaurus/utils': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/utils-validation': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       algoliasearch: 4.24.0
       algoliasearch-helper: 3.22.5(algoliasearch@4.24.0)
       clsx: 2.1.1
@@ -7344,7 +8014,6 @@ snapshots:
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@docusaurus/faster'
-      - '@docusaurus/types'
       - '@mdx-js/react'
       - '@parcel/css'
       - '@rspack/core'
@@ -7366,12 +8035,12 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-translations@3.5.2-canary-6127':
+  '@docusaurus/theme-translations@3.6.2':
     dependencies:
       fs-extra: 11.2.0
       tslib: 2.8.0
 
-  '@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@mdx-js/mdx': 3.1.0(acorn@8.14.0)
       '@types/history': 4.7.11
@@ -7392,35 +8061,46 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-common@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@docusaurus/utils-common@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
+      '@docusaurus/types': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tslib: 2.8.0
-    optionalDependencies:
-      '@docusaurus/types': 3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - '@swc/core'
+      - acorn
+      - esbuild
+      - react
+      - react-dom
+      - supports-color
+      - uglify-js
+      - webpack-cli
 
-  '@docusaurus/utils-validation@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)':
+  '@docusaurus/utils-validation@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
-      '@docusaurus/logger': 3.5.2-canary-6127
-      '@docusaurus/utils': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)
-      '@docusaurus/utils-common': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@docusaurus/logger': 3.6.2
+      '@docusaurus/utils': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/utils-common': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       fs-extra: 11.2.0
       joi: 17.13.3
       js-yaml: 4.1.0
       lodash: 4.17.21
       tslib: 2.8.0
     transitivePeerDependencies:
-      - '@docusaurus/types'
       - '@swc/core'
+      - acorn
       - esbuild
+      - react
+      - react-dom
       - supports-color
       - typescript
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.42)(typescript@5.6.3)':
+  '@docusaurus/utils@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
-      '@docusaurus/logger': 3.5.2-canary-6127
-      '@docusaurus/utils-common': 3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@docusaurus/logger': 3.6.2
+      '@docusaurus/types': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-common': 3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@svgr/webpack': 8.1.0(typescript@5.6.3)
       escape-string-regexp: 4.0.0
       file-loader: 6.2.0(webpack@5.95.0(@swc/core@1.7.42))
@@ -7439,11 +8119,12 @@ snapshots:
       url-loader: 4.1.1(file-loader@6.2.0(webpack@5.95.0(@swc/core@1.7.42)))(webpack@5.95.0(@swc/core@1.7.42))
       utility-types: 3.11.0
       webpack: 5.95.0(@swc/core@1.7.42)
-    optionalDependencies:
-      '@docusaurus/types': 3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - '@swc/core'
+      - acorn
       - esbuild
+      - react
+      - react-dom
       - supports-color
       - typescript
       - uglify-js
@@ -7588,49 +8269,49 @@ snapshots:
 
   '@polka/url@1.0.0-next.28': {}
 
-  '@rspack/binding-darwin-arm64@1.0.14':
+  '@rspack/binding-darwin-arm64@1.1.2':
     optional: true
 
-  '@rspack/binding-darwin-x64@1.0.14':
+  '@rspack/binding-darwin-x64@1.1.2':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@1.0.14':
+  '@rspack/binding-linux-arm64-gnu@1.1.2':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@1.0.14':
+  '@rspack/binding-linux-arm64-musl@1.1.2':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@1.0.14':
+  '@rspack/binding-linux-x64-gnu@1.1.2':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@1.0.14':
+  '@rspack/binding-linux-x64-musl@1.1.2':
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@1.0.14':
+  '@rspack/binding-win32-arm64-msvc@1.1.2':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@1.0.14':
+  '@rspack/binding-win32-ia32-msvc@1.1.2':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@1.0.14':
+  '@rspack/binding-win32-x64-msvc@1.1.2':
     optional: true
 
-  '@rspack/binding@1.0.14':
+  '@rspack/binding@1.1.2':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.0.14
-      '@rspack/binding-darwin-x64': 1.0.14
-      '@rspack/binding-linux-arm64-gnu': 1.0.14
-      '@rspack/binding-linux-arm64-musl': 1.0.14
-      '@rspack/binding-linux-x64-gnu': 1.0.14
-      '@rspack/binding-linux-x64-musl': 1.0.14
-      '@rspack/binding-win32-arm64-msvc': 1.0.14
-      '@rspack/binding-win32-ia32-msvc': 1.0.14
-      '@rspack/binding-win32-x64-msvc': 1.0.14
+      '@rspack/binding-darwin-arm64': 1.1.2
+      '@rspack/binding-darwin-x64': 1.1.2
+      '@rspack/binding-linux-arm64-gnu': 1.1.2
+      '@rspack/binding-linux-arm64-musl': 1.1.2
+      '@rspack/binding-linux-x64-gnu': 1.1.2
+      '@rspack/binding-linux-x64-musl': 1.1.2
+      '@rspack/binding-win32-arm64-msvc': 1.1.2
+      '@rspack/binding-win32-ia32-msvc': 1.1.2
+      '@rspack/binding-win32-x64-msvc': 1.1.2
 
-  '@rspack/core@1.0.14':
+  '@rspack/core@1.1.2':
     dependencies:
       '@module-federation/runtime-tools': 0.5.1
-      '@rspack/binding': 1.0.14
+      '@rspack/binding': 1.1.2
       '@rspack/lite-tapable': 1.0.1
       caniuse-lite: 1.0.30001673
 
@@ -8183,7 +8864,7 @@ snapshots:
 
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 22.8.1
 
   '@types/send@0.17.4':
     dependencies:
@@ -8878,11 +9559,23 @@ snapshots:
     dependencies:
       type-fest: 1.4.0
 
+  css-blank-pseudo@7.0.1(postcss@8.4.47):
+    dependencies:
+      postcss: 8.4.47
+      postcss-selector-parser: 7.0.0
+
   css-declaration-sorter@7.2.0(postcss@8.4.47):
     dependencies:
       postcss: 8.4.47
 
-  css-loader@6.11.0(@rspack/core@1.0.14)(webpack@5.95.0(@swc/core@1.7.42)):
+  css-has-pseudo@7.0.1(postcss@8.4.47):
+    dependencies:
+      '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.0.0)
+      postcss: 8.4.47
+      postcss-selector-parser: 7.0.0
+      postcss-value-parser: 4.2.0
+
+  css-loader@6.11.0(@rspack/core@1.1.2)(webpack@5.95.0(@swc/core@1.7.42)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.47)
       postcss: 8.4.47
@@ -8893,7 +9586,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.3
     optionalDependencies:
-      '@rspack/core': 1.0.14
+      '@rspack/core': 1.1.2
       webpack: 5.95.0(@swc/core@1.7.42)
 
   css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(webpack@5.95.0(@swc/core@1.7.42)):
@@ -8907,6 +9600,10 @@ snapshots:
       webpack: 5.95.0(@swc/core@1.7.42)
     optionalDependencies:
       clean-css: 5.3.3
+
+  css-prefers-color-scheme@10.0.0(postcss@8.4.47):
+    dependencies:
+      postcss: 8.4.47
 
   css-select-base-adapter@0.1.1: {}
 
@@ -8956,6 +9653,8 @@ snapshots:
   css-what@3.4.2: {}
 
   css-what@6.1.0: {}
+
+  cssdb@8.2.1: {}
 
   cssesc@3.0.0: {}
 
@@ -9323,9 +10022,9 @@ snapshots:
     dependencies:
       '@leichtgewicht/ip-codec': 2.0.5
 
-  docusaurus-plugin-image-zoom@1.0.1(@docusaurus/theme-classic@3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@rspack/core@1.0.14)(@swc/core@1.7.42)(@types/react@18.3.12)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)):
+  docusaurus-plugin-image-zoom@1.0.1(@docusaurus/theme-classic@3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@rspack/core@1.1.2)(@swc/core@1.7.42)(@types/react@18.3.12)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)):
     dependencies:
-      '@docusaurus/theme-classic': 3.5.2-canary-6127(@docusaurus/faster@3.5.2-canary-6127(@docusaurus/types@3.5.2-canary-6127(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@rspack/core@1.0.14)(@swc/core@1.7.42)(@types/react@18.3.12)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/theme-classic': 3.6.2(@docusaurus/faster@3.6.2(@docusaurus/types@3.6.2(@swc/core@1.7.42)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@rspack/core@1.1.2)(@swc/core@1.7.42)(@types/react@18.3.12)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       medium-zoom: 1.1.0
       validate-peer-dependencies: 2.2.0
 
@@ -10088,7 +10787,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.3(@rspack/core@1.0.14)(webpack@5.95.0(@swc/core@1.7.42)):
+  html-webpack-plugin@5.6.3(@rspack/core@1.1.2)(webpack@5.95.0(@swc/core@1.7.42)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -10096,7 +10795,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.2.1
     optionalDependencies:
-      '@rspack/core': 1.0.14
+      '@rspack/core': 1.1.2
       webpack: 5.95.0(@swc/core@1.7.42)
 
   htmlparser2@6.1.0:
@@ -11492,10 +12191,41 @@ snapshots:
 
   possible-typed-array-names@1.0.0: {}
 
+  postcss-attribute-case-insensitive@7.0.1(postcss@8.4.47):
+    dependencies:
+      postcss: 8.4.47
+      postcss-selector-parser: 7.0.0
+
   postcss-calc@9.0.1(postcss@8.4.47):
     dependencies:
       postcss: 8.4.47
       postcss-selector-parser: 6.1.2
+      postcss-value-parser: 4.2.0
+
+  postcss-clamp@4.1.0(postcss@8.4.47):
+    dependencies:
+      postcss: 8.4.47
+      postcss-value-parser: 4.2.0
+
+  postcss-color-functional-notation@7.0.6(postcss@8.4.47):
+    dependencies:
+      '@csstools/css-color-parser': 3.0.6(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.47)
+      '@csstools/utilities': 2.0.0(postcss@8.4.47)
+      postcss: 8.4.47
+
+  postcss-color-hex-alpha@10.0.0(postcss@8.4.47):
+    dependencies:
+      '@csstools/utilities': 2.0.0(postcss@8.4.47)
+      postcss: 8.4.47
+      postcss-value-parser: 4.2.0
+
+  postcss-color-rebeccapurple@10.0.0(postcss@8.4.47):
+    dependencies:
+      '@csstools/utilities': 2.0.0(postcss@8.4.47)
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
 
   postcss-colormin@6.1.0(postcss@8.4.47):
@@ -11511,6 +12241,36 @@ snapshots:
       browserslist: 4.24.2
       postcss: 8.4.47
       postcss-value-parser: 4.2.0
+
+  postcss-custom-media@11.0.5(postcss@8.4.47):
+    dependencies:
+      '@csstools/cascade-layer-name-parser': 2.0.4(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      postcss: 8.4.47
+
+  postcss-custom-properties@14.0.4(postcss@8.4.47):
+    dependencies:
+      '@csstools/cascade-layer-name-parser': 2.0.4(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/utilities': 2.0.0(postcss@8.4.47)
+      postcss: 8.4.47
+      postcss-value-parser: 4.2.0
+
+  postcss-custom-selectors@8.0.4(postcss@8.4.47):
+    dependencies:
+      '@csstools/cascade-layer-name-parser': 2.0.4(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      postcss: 8.4.47
+      postcss-selector-parser: 7.0.0
+
+  postcss-dir-pseudo-class@9.0.1(postcss@8.4.47):
+    dependencies:
+      postcss: 8.4.47
+      postcss-selector-parser: 7.0.0
 
   postcss-discard-comments@6.0.2(postcss@8.4.47):
     dependencies:
@@ -11533,6 +12293,46 @@ snapshots:
       postcss: 8.4.47
       postcss-selector-parser: 6.1.2
 
+  postcss-double-position-gradients@6.0.0(postcss@8.4.47):
+    dependencies:
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.47)
+      '@csstools/utilities': 2.0.0(postcss@8.4.47)
+      postcss: 8.4.47
+      postcss-value-parser: 4.2.0
+
+  postcss-focus-visible@10.0.1(postcss@8.4.47):
+    dependencies:
+      postcss: 8.4.47
+      postcss-selector-parser: 7.0.0
+
+  postcss-focus-within@9.0.1(postcss@8.4.47):
+    dependencies:
+      postcss: 8.4.47
+      postcss-selector-parser: 7.0.0
+
+  postcss-font-variant@5.0.0(postcss@8.4.47):
+    dependencies:
+      postcss: 8.4.47
+
+  postcss-gap-properties@6.0.0(postcss@8.4.47):
+    dependencies:
+      postcss: 8.4.47
+
+  postcss-image-set-function@7.0.0(postcss@8.4.47):
+    dependencies:
+      '@csstools/utilities': 2.0.0(postcss@8.4.47)
+      postcss: 8.4.47
+      postcss-value-parser: 4.2.0
+
+  postcss-lab-function@7.0.6(postcss@8.4.47):
+    dependencies:
+      '@csstools/css-color-parser': 3.0.6(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.47)
+      '@csstools/utilities': 2.0.0(postcss@8.4.47)
+      postcss: 8.4.47
+
   postcss-loader@7.3.4(postcss@8.4.47)(typescript@5.6.3)(webpack@5.95.0(@swc/core@1.7.42)):
     dependencies:
       cosmiconfig: 8.3.6(typescript@5.6.3)
@@ -11542,6 +12342,11 @@ snapshots:
       webpack: 5.95.0(@swc/core@1.7.42)
     transitivePeerDependencies:
       - typescript
+
+  postcss-logical@8.0.0(postcss@8.4.47):
+    dependencies:
+      postcss: 8.4.47
+      postcss-value-parser: 4.2.0
 
   postcss-merge-idents@6.0.3(postcss@8.4.47):
     dependencies:
@@ -11608,6 +12413,13 @@ snapshots:
       icss-utils: 5.1.0(postcss@8.4.47)
       postcss: 8.4.47
 
+  postcss-nesting@13.0.1(postcss@8.4.47):
+    dependencies:
+      '@csstools/selector-resolve-nested': 3.0.0(postcss-selector-parser@7.0.0)
+      '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.0.0)
+      postcss: 8.4.47
+      postcss-selector-parser: 7.0.0
+
   postcss-normalize-charset@6.0.2(postcss@8.4.47):
     dependencies:
       postcss: 8.4.47
@@ -11653,11 +12465,101 @@ snapshots:
       postcss: 8.4.47
       postcss-value-parser: 4.2.0
 
+  postcss-opacity-percentage@3.0.0(postcss@8.4.47):
+    dependencies:
+      postcss: 8.4.47
+
   postcss-ordered-values@6.0.2(postcss@8.4.47):
     dependencies:
       cssnano-utils: 4.0.2(postcss@8.4.47)
       postcss: 8.4.47
       postcss-value-parser: 4.2.0
+
+  postcss-overflow-shorthand@6.0.0(postcss@8.4.47):
+    dependencies:
+      postcss: 8.4.47
+      postcss-value-parser: 4.2.0
+
+  postcss-page-break@3.0.4(postcss@8.4.47):
+    dependencies:
+      postcss: 8.4.47
+
+  postcss-place@10.0.0(postcss@8.4.47):
+    dependencies:
+      postcss: 8.4.47
+      postcss-value-parser: 4.2.0
+
+  postcss-preset-env@10.1.1(postcss@8.4.47):
+    dependencies:
+      '@csstools/postcss-cascade-layers': 5.0.1(postcss@8.4.47)
+      '@csstools/postcss-color-function': 4.0.6(postcss@8.4.47)
+      '@csstools/postcss-color-mix-function': 3.0.6(postcss@8.4.47)
+      '@csstools/postcss-content-alt-text': 2.0.4(postcss@8.4.47)
+      '@csstools/postcss-exponential-functions': 2.0.5(postcss@8.4.47)
+      '@csstools/postcss-font-format-keywords': 4.0.0(postcss@8.4.47)
+      '@csstools/postcss-gamut-mapping': 2.0.6(postcss@8.4.47)
+      '@csstools/postcss-gradients-interpolation-method': 5.0.6(postcss@8.4.47)
+      '@csstools/postcss-hwb-function': 4.0.6(postcss@8.4.47)
+      '@csstools/postcss-ic-unit': 4.0.0(postcss@8.4.47)
+      '@csstools/postcss-initial': 2.0.0(postcss@8.4.47)
+      '@csstools/postcss-is-pseudo-class': 5.0.1(postcss@8.4.47)
+      '@csstools/postcss-light-dark-function': 2.0.7(postcss@8.4.47)
+      '@csstools/postcss-logical-float-and-clear': 3.0.0(postcss@8.4.47)
+      '@csstools/postcss-logical-overflow': 2.0.0(postcss@8.4.47)
+      '@csstools/postcss-logical-overscroll-behavior': 2.0.0(postcss@8.4.47)
+      '@csstools/postcss-logical-resize': 3.0.0(postcss@8.4.47)
+      '@csstools/postcss-logical-viewport-units': 3.0.3(postcss@8.4.47)
+      '@csstools/postcss-media-minmax': 2.0.5(postcss@8.4.47)
+      '@csstools/postcss-media-queries-aspect-ratio-number-values': 3.0.4(postcss@8.4.47)
+      '@csstools/postcss-nested-calc': 4.0.0(postcss@8.4.47)
+      '@csstools/postcss-normalize-display-values': 4.0.0(postcss@8.4.47)
+      '@csstools/postcss-oklab-function': 4.0.6(postcss@8.4.47)
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.47)
+      '@csstools/postcss-random-function': 1.0.1(postcss@8.4.47)
+      '@csstools/postcss-relative-color-syntax': 3.0.6(postcss@8.4.47)
+      '@csstools/postcss-scope-pseudo-class': 4.0.1(postcss@8.4.47)
+      '@csstools/postcss-sign-functions': 1.1.0(postcss@8.4.47)
+      '@csstools/postcss-stepped-value-functions': 4.0.5(postcss@8.4.47)
+      '@csstools/postcss-text-decoration-shorthand': 4.0.1(postcss@8.4.47)
+      '@csstools/postcss-trigonometric-functions': 4.0.5(postcss@8.4.47)
+      '@csstools/postcss-unset-value': 4.0.0(postcss@8.4.47)
+      autoprefixer: 10.4.20(postcss@8.4.47)
+      browserslist: 4.24.2
+      css-blank-pseudo: 7.0.1(postcss@8.4.47)
+      css-has-pseudo: 7.0.1(postcss@8.4.47)
+      css-prefers-color-scheme: 10.0.0(postcss@8.4.47)
+      cssdb: 8.2.1
+      postcss: 8.4.47
+      postcss-attribute-case-insensitive: 7.0.1(postcss@8.4.47)
+      postcss-clamp: 4.1.0(postcss@8.4.47)
+      postcss-color-functional-notation: 7.0.6(postcss@8.4.47)
+      postcss-color-hex-alpha: 10.0.0(postcss@8.4.47)
+      postcss-color-rebeccapurple: 10.0.0(postcss@8.4.47)
+      postcss-custom-media: 11.0.5(postcss@8.4.47)
+      postcss-custom-properties: 14.0.4(postcss@8.4.47)
+      postcss-custom-selectors: 8.0.4(postcss@8.4.47)
+      postcss-dir-pseudo-class: 9.0.1(postcss@8.4.47)
+      postcss-double-position-gradients: 6.0.0(postcss@8.4.47)
+      postcss-focus-visible: 10.0.1(postcss@8.4.47)
+      postcss-focus-within: 9.0.1(postcss@8.4.47)
+      postcss-font-variant: 5.0.0(postcss@8.4.47)
+      postcss-gap-properties: 6.0.0(postcss@8.4.47)
+      postcss-image-set-function: 7.0.0(postcss@8.4.47)
+      postcss-lab-function: 7.0.6(postcss@8.4.47)
+      postcss-logical: 8.0.0(postcss@8.4.47)
+      postcss-nesting: 13.0.1(postcss@8.4.47)
+      postcss-opacity-percentage: 3.0.0(postcss@8.4.47)
+      postcss-overflow-shorthand: 6.0.0(postcss@8.4.47)
+      postcss-page-break: 3.0.4(postcss@8.4.47)
+      postcss-place: 10.0.0(postcss@8.4.47)
+      postcss-pseudo-class-any-link: 10.0.1(postcss@8.4.47)
+      postcss-replace-overflow-wrap: 4.0.0(postcss@8.4.47)
+      postcss-selector-not: 8.0.1(postcss@8.4.47)
+
+  postcss-pseudo-class-any-link@10.0.1(postcss@8.4.47):
+    dependencies:
+      postcss: 8.4.47
+      postcss-selector-parser: 7.0.0
 
   postcss-reduce-idents@6.0.3(postcss@8.4.47):
     dependencies:
@@ -11675,7 +12577,21 @@ snapshots:
       postcss: 8.4.47
       postcss-value-parser: 4.2.0
 
+  postcss-replace-overflow-wrap@4.0.0(postcss@8.4.47):
+    dependencies:
+      postcss: 8.4.47
+
+  postcss-selector-not@8.0.1(postcss@8.4.47):
+    dependencies:
+      postcss: 8.4.47
+      postcss-selector-parser: 7.0.0
+
   postcss-selector-parser@6.1.2:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
+  postcss-selector-parser@7.0.0:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2


### PR DESCRIPTION
升级 Docusaurus 至 3.6.2，以修复开发环境无法启动的问题。

```release-note
None
```