### PR TITLE
fix: correct getByNames method examples for category and tag api

### DIFF
--- a/docs/developer-guide/theme/finder-apis/category.md
+++ b/docs/developer-guide/theme/finder-apis/category.md
@@ -12,6 +12,10 @@ import CategoryTreeVo from "../vo/_CategoryTreeVo.md"
 categoryFinder.getByName(name)
 ```
 
+:::info 提示
+通常建议配合 [主题设置](../settings.md) 和 [分类选择器](../../form-schema.md#categoryselect) 使用，让用户自行选择所需的分类。
+:::
+
 ### 描述
 
 根据 `metadata.name` 获取文章分类。
@@ -38,6 +42,10 @@ categoryFinder.getByName(name)
 categoryFinder.getByNames(names)
 ```
 
+:::info 提示
+通常建议配合 [主题设置](../settings.md) 和 [分类选择器](../../form-schema.md#categoryselect) 使用，让用户自行选择所需的分类。
+:::
+
 ### 描述
 
 根据一组 `metadata.name` 获取文章分类。
@@ -53,7 +61,7 @@ List\<[#CategoryVo](#categoryvo)\>
 ### 示例
 
 ```html
-<div th:with="categories = ${categoryFinder.getByNames(['category-foo', 'category-bar'])}">
+<div th:with="categories = ${categoryFinder.getByNames({'category-foo', 'category-bar'})}">
   <a th:each="category : ${categories}" th:href="@{${category.status.permalink}}" th:text="${category.spec.displayName}"></a>
 </div>
 ```

--- a/docs/developer-guide/theme/finder-apis/contributor.md
+++ b/docs/developer-guide/theme/finder-apis/contributor.md
@@ -52,7 +52,7 @@ List\<[#ContributorVo](#contributorvo)\>
 ### 示例
 
 ```html
-<div th:with="contributors = ${contributorFinder.getContributors(['contributor-foo, 'contributor-bar'])}">
+<div th:with="contributors = ${contributorFinder.getContributors({'contributor-foo, 'contributor-bar'})}">
   <span th:each="contributor : ${contributors}" th:text="${contributor.displayName}"></span>
 </div>
 ```

--- a/docs/developer-guide/theme/finder-apis/tag.md
+++ b/docs/developer-guide/theme/finder-apis/tag.md
@@ -11,6 +11,10 @@ import TagVo from "../vo/_TagVo.md"
 tagFinder.getByName(name)
 ```
 
+:::info 提示
+通常建议配合 [主题设置](../settings.md) 和 [标签选择器](../../form-schema.md#tagselect) 使用，让用户自行选择所需的标签。
+:::
+
 ### 描述
 
 根据 `metadata.name` 获取标签。
@@ -37,6 +41,10 @@ tagFinder.getByName(name)
 tagFinder.getByNames(names)
 ```
 
+:::info 提示
+通常建议配合 [主题设置](../settings.md) 和 [标签选择器](../../form-schema.md#tagselect) 使用，让用户自行选择所需的标签。
+:::
+
 ### 描述
 
 根据一组 `metadata.name` 获取标签。
@@ -52,7 +60,7 @@ List\<[#TagVo](#tagvo)\>
 ### 示例
 
 ```html
-<div th:with="tags = ${tagFinder.getByNames(['tag-foo', 'tag-bar'])}">
+<div th:with="tags = ${tagFinder.getByNames({'tag-foo', 'tag-bar'})}">
   <a th:each="tag : ${tags}" th:href="@{${tag.status.permalink}}" th:text="${tag.spec.displayName}"></a>
 </div>
 ```

--- a/versioned_docs/version-2.16/developer-guide/theme/finder-apis/category.md
+++ b/versioned_docs/version-2.16/developer-guide/theme/finder-apis/category.md
@@ -53,7 +53,7 @@ List\<[#CategoryVo](#categoryvo)\>
 ### 示例
 
 ```html
-<div th:with="categories = ${categoryFinder.getByNames(['category-foo', 'category-bar'])}">
+<div th:with="categories = ${categoryFinder.getByNames({'category-foo', 'category-bar'})}">
   <a th:each="category : ${categories}" th:href="@{${category.status.permalink}}" th:text="${category.spec.displayName}"></a>
 </div>
 ```

--- a/versioned_docs/version-2.16/developer-guide/theme/finder-apis/contributor.md
+++ b/versioned_docs/version-2.16/developer-guide/theme/finder-apis/contributor.md
@@ -52,7 +52,7 @@ List\<[#ContributorVo](#contributorvo)\>
 ### 示例
 
 ```html
-<div th:with="contributors = ${contributorFinder.getContributors(['contributor-foo, 'contributor-bar'])}">
+<div th:with="contributors = ${contributorFinder.getContributors({'contributor-foo, 'contributor-bar'})}">
   <span th:each="contributor : ${contributors}" th:text="${contributor.displayName}"></span>
 </div>
 ```

--- a/versioned_docs/version-2.16/developer-guide/theme/finder-apis/tag.md
+++ b/versioned_docs/version-2.16/developer-guide/theme/finder-apis/tag.md
@@ -52,7 +52,7 @@ List\<[#TagVo](#tagvo)\>
 ### 示例
 
 ```html
-<div th:with="tags = ${tagFinder.getByNames(['tag-foo', 'tag-bar'])}">
+<div th:with="tags = ${tagFinder.getByNames({'tag-foo', 'tag-bar'})}">
   <a th:each="tag : ${tags}" th:href="@{${tag.status.permalink}}" th:text="${tag.spec.displayName}"></a>
 </div>
 ```

--- a/versioned_docs/version-2.17/developer-guide/theme/finder-apis/category.md
+++ b/versioned_docs/version-2.17/developer-guide/theme/finder-apis/category.md
@@ -53,7 +53,7 @@ List\<[#CategoryVo](#categoryvo)\>
 ### 示例
 
 ```html
-<div th:with="categories = ${categoryFinder.getByNames(['category-foo', 'category-bar'])}">
+<div th:with="categories = ${categoryFinder.getByNames({'category-foo', 'category-bar'})}">
   <a th:each="category : ${categories}" th:href="@{${category.status.permalink}}" th:text="${category.spec.displayName}"></a>
 </div>
 ```

--- a/versioned_docs/version-2.17/developer-guide/theme/finder-apis/contributor.md
+++ b/versioned_docs/version-2.17/developer-guide/theme/finder-apis/contributor.md
@@ -52,7 +52,7 @@ List\<[#ContributorVo](#contributorvo)\>
 ### 示例
 
 ```html
-<div th:with="contributors = ${contributorFinder.getContributors(['contributor-foo, 'contributor-bar'])}">
+<div th:with="contributors = ${contributorFinder.getContributors({'contributor-foo, 'contributor-bar'})}">
   <span th:each="contributor : ${contributors}" th:text="${contributor.displayName}"></span>
 </div>
 ```

--- a/versioned_docs/version-2.17/developer-guide/theme/finder-apis/tag.md
+++ b/versioned_docs/version-2.17/developer-guide/theme/finder-apis/tag.md
@@ -52,7 +52,7 @@ List\<[#TagVo](#tagvo)\>
 ### 示例
 
 ```html
-<div th:with="tags = ${tagFinder.getByNames(['tag-foo', 'tag-bar'])}">
+<div th:with="tags = ${tagFinder.getByNames({'tag-foo', 'tag-bar'})}">
   <a th:each="tag : ${tags}" th:href="@{${tag.status.permalink}}" th:text="${tag.spec.displayName}"></a>
 </div>
 ```

--- a/versioned_docs/version-2.18/developer-guide/theme/finder-apis/category.md
+++ b/versioned_docs/version-2.18/developer-guide/theme/finder-apis/category.md
@@ -53,7 +53,7 @@ List\<[#CategoryVo](#categoryvo)\>
 ### 示例
 
 ```html
-<div th:with="categories = ${categoryFinder.getByNames(['category-foo', 'category-bar'])}">
+<div th:with="categories = ${categoryFinder.getByNames({'category-foo', 'category-bar'})}">
   <a th:each="category : ${categories}" th:href="@{${category.status.permalink}}" th:text="${category.spec.displayName}"></a>
 </div>
 ```

--- a/versioned_docs/version-2.18/developer-guide/theme/finder-apis/contributor.md
+++ b/versioned_docs/version-2.18/developer-guide/theme/finder-apis/contributor.md
@@ -52,7 +52,7 @@ List\<[#ContributorVo](#contributorvo)\>
 ### 示例
 
 ```html
-<div th:with="contributors = ${contributorFinder.getContributors(['contributor-foo, 'contributor-bar'])}">
+<div th:with="contributors = ${contributorFinder.getContributors({'contributor-foo, 'contributor-bar'})}">
   <span th:each="contributor : ${contributors}" th:text="${contributor.displayName}"></span>
 </div>
 ```

--- a/versioned_docs/version-2.18/developer-guide/theme/finder-apis/tag.md
+++ b/versioned_docs/version-2.18/developer-guide/theme/finder-apis/tag.md
@@ -52,7 +52,7 @@ List\<[#TagVo](#tagvo)\>
 ### 示例
 
 ```html
-<div th:with="tags = ${tagFinder.getByNames(['tag-foo', 'tag-bar'])}">
+<div th:with="tags = ${tagFinder.getByNames({'tag-foo', 'tag-bar'})}">
   <a th:each="tag : ${tags}" th:href="@{${tag.status.permalink}}" th:text="${tag.spec.displayName}"></a>
 </div>
 ```

--- a/versioned_docs/version-2.19/developer-guide/theme/finder-apis/category.md
+++ b/versioned_docs/version-2.19/developer-guide/theme/finder-apis/category.md
@@ -53,7 +53,7 @@ List\<[#CategoryVo](#categoryvo)\>
 ### 示例
 
 ```html
-<div th:with="categories = ${categoryFinder.getByNames(['category-foo', 'category-bar'])}">
+<div th:with="categories = ${categoryFinder.getByNames({'category-foo', 'category-bar'})}">
   <a th:each="category : ${categories}" th:href="@{${category.status.permalink}}" th:text="${category.spec.displayName}"></a>
 </div>
 ```

--- a/versioned_docs/version-2.19/developer-guide/theme/finder-apis/contributor.md
+++ b/versioned_docs/version-2.19/developer-guide/theme/finder-apis/contributor.md
@@ -52,7 +52,7 @@ List\<[#ContributorVo](#contributorvo)\>
 ### 示例
 
 ```html
-<div th:with="contributors = ${contributorFinder.getContributors(['contributor-foo, 'contributor-bar'])}">
+<div th:with="contributors = ${contributorFinder.getContributors({'contributor-foo, 'contributor-bar'})}">
   <span th:each="contributor : ${contributors}" th:text="${contributor.displayName}"></span>
 </div>
 ```

--- a/versioned_docs/version-2.19/developer-guide/theme/finder-apis/tag.md
+++ b/versioned_docs/version-2.19/developer-guide/theme/finder-apis/tag.md
@@ -52,7 +52,7 @@ List\<[#TagVo](#tagvo)\>
 ### 示例
 
 ```html
-<div th:with="tags = ${tagFinder.getByNames(['tag-foo', 'tag-bar'])}">
+<div th:with="tags = ${tagFinder.getByNames({'tag-foo', 'tag-bar'})}">
   <a th:each="tag : ${tags}" th:href="@{${tag.status.permalink}}" th:text="${tag.spec.displayName}"></a>
 </div>
 ```

--- a/versioned_docs/version-2.20/developer-guide/theme/finder-apis/category.md
+++ b/versioned_docs/version-2.20/developer-guide/theme/finder-apis/category.md
@@ -12,6 +12,10 @@ import CategoryTreeVo from "../vo/_CategoryTreeVo.md"
 categoryFinder.getByName(name)
 ```
 
+:::info 提示
+通常建议配合 [主题设置](../settings.md) 和 [分类选择器](../../form-schema.md#categoryselect) 使用，让用户自行选择所需的分类。
+:::
+
 ### 描述
 
 根据 `metadata.name` 获取文章分类。
@@ -38,6 +42,10 @@ categoryFinder.getByName(name)
 categoryFinder.getByNames(names)
 ```
 
+:::info 提示
+通常建议配合 [主题设置](../settings.md) 和 [分类选择器](../../form-schema.md#categoryselect) 使用，让用户自行选择所需的分类。
+:::
+
 ### 描述
 
 根据一组 `metadata.name` 获取文章分类。
@@ -53,7 +61,7 @@ List\<[#CategoryVo](#categoryvo)\>
 ### 示例
 
 ```html
-<div th:with="categories = ${categoryFinder.getByNames(['category-foo', 'category-bar'])}">
+<div th:with="categories = ${categoryFinder.getByNames({'category-foo', 'category-bar'})}">
   <a th:each="category : ${categories}" th:href="@{${category.status.permalink}}" th:text="${category.spec.displayName}"></a>
 </div>
 ```

--- a/versioned_docs/version-2.20/developer-guide/theme/finder-apis/contributor.md
+++ b/versioned_docs/version-2.20/developer-guide/theme/finder-apis/contributor.md
@@ -52,7 +52,7 @@ List\<[#ContributorVo](#contributorvo)\>
 ### 示例
 
 ```html
-<div th:with="contributors = ${contributorFinder.getContributors(['contributor-foo, 'contributor-bar'])}">
+<div th:with="contributors = ${contributorFinder.getContributors({'contributor-foo, 'contributor-bar'})}">
   <span th:each="contributor : ${contributors}" th:text="${contributor.displayName}"></span>
 </div>
 ```

--- a/versioned_docs/version-2.20/developer-guide/theme/finder-apis/tag.md
+++ b/versioned_docs/version-2.20/developer-guide/theme/finder-apis/tag.md
@@ -11,6 +11,10 @@ import TagVo from "../vo/_TagVo.md"
 tagFinder.getByName(name)
 ```
 
+:::info 提示
+通常建议配合 [主题设置](../settings.md) 和 [标签选择器](../../form-schema.md#tagselect) 使用，让用户自行选择所需的标签。
+:::
+
 ### 描述
 
 根据 `metadata.name` 获取标签。
@@ -37,6 +41,10 @@ tagFinder.getByName(name)
 tagFinder.getByNames(names)
 ```
 
+:::info 提示
+通常建议配合 [主题设置](../settings.md) 和 [标签选择器](../../form-schema.md#tagselect) 使用，让用户自行选择所需的标签。
+:::
+
 ### 描述
 
 根据一组 `metadata.name` 获取标签。
@@ -52,7 +60,7 @@ List\<[#TagVo](#tagvo)\>
 ### 示例
 
 ```html
-<div th:with="tags = ${tagFinder.getByNames(['tag-foo', 'tag-bar'])}">
+<div th:with="tags = ${tagFinder.getByNames({'tag-foo', 'tag-bar'})}">
   <a th:each="tag : ${tags}" th:href="@{${tag.status.permalink}}" th:text="${tag.spec.displayName}"></a>
 </div>
 ```


### PR DESCRIPTION
修复 categoryFinder 和 tagFinder 关于 getByNames 的错误示例。

Fixes https://github.com/halo-dev/docs/issues/475

```release-note
None
```