### PR TITLE
docs: remove page cache config for jar-file document

### DIFF
--- a/docs/getting-started/install/jar-file.md
+++ b/docs/getting-started/install/jar-file.md
@@ -92,10 +92,6 @@ title: 使用 JAR 文件部署
          # 需要配合 r2dbc 的配置进行改动
          platform: h2
    halo:
-     caches:
-       page:
-         # 是否禁用页面缓存
-         disabled: true
      # 工作目录位置
      work-dir: ${user.home}/.halo2
      # 外部访问地址

--- a/versioned_docs/version-2.17/getting-started/install/jar-file.md
+++ b/versioned_docs/version-2.17/getting-started/install/jar-file.md
@@ -92,10 +92,6 @@ title: 使用 JAR 文件部署
          # 需要配合 r2dbc 的配置进行改动
          platform: h2
    halo:
-     caches:
-       page:
-         # 是否禁用页面缓存
-         disabled: true
      # 工作目录位置
      work-dir: ${user.home}/.halo2
      # 外部访问地址

--- a/versioned_docs/version-2.18/getting-started/install/jar-file.md
+++ b/versioned_docs/version-2.18/getting-started/install/jar-file.md
@@ -92,10 +92,6 @@ title: 使用 JAR 文件部署
          # 需要配合 r2dbc 的配置进行改动
          platform: h2
    halo:
-     caches:
-       page:
-         # 是否禁用页面缓存
-         disabled: true
      # 工作目录位置
      work-dir: ${user.home}/.halo2
      # 外部访问地址

--- a/versioned_docs/version-2.19/getting-started/install/jar-file.md
+++ b/versioned_docs/version-2.19/getting-started/install/jar-file.md
@@ -92,10 +92,6 @@ title: 使用 JAR 文件部署
          # 需要配合 r2dbc 的配置进行改动
          platform: h2
    halo:
-     caches:
-       page:
-         # 是否禁用页面缓存
-         disabled: true
      # 工作目录位置
      work-dir: ${user.home}/.halo2
      # 外部访问地址

--- a/versioned_docs/version-2.20/getting-started/install/jar-file.md
+++ b/versioned_docs/version-2.20/getting-started/install/jar-file.md
@@ -92,10 +92,6 @@ title: 使用 JAR 文件部署
          # 需要配合 r2dbc 的配置进行改动
          platform: h2
    halo:
-     caches:
-       page:
-         # 是否禁用页面缓存
-         disabled: true
      # 工作目录位置
      work-dir: ${user.home}/.halo2
      # 外部访问地址


### PR DESCRIPTION
移除 Jar 部署方式中配置示例的页面缓存配置，这个配置已经在 2.17+ 移除。

```release-note
None
```