### PR TITLE
Document secret description preset

### DIFF
--- a/docs/developer-guide/form-schema.md
+++ b/docs/developer-guide/form-schema.md
@@ -858,6 +858,7 @@ UI 效果：
 - `requiredKeys`：所需的密钥字段，用于为用户说明所选的密钥资源中需要包含的字段，此字段为对象数组类型，对象包含以下属性：
   - `key`：密钥字段名称
   - `help`：密钥字段名称的描述
+- `descriptionPreset`：创建密钥时的备注预设。打开创建密钥弹窗时，备注字段会预填为 `<descriptionPreset> - <当前时间>`，用户仍可在保存前编辑。
 
 #### 示例
 
@@ -865,6 +866,7 @@ UI 效果：
 - $formkit: secret
   name: secret
   label: 密钥
+  descriptionPreset: 第三方 API
   requiredKeys:
     - key: apiKey
       help: API 密钥

--- a/docs/developer-guide/plugin/api-changelog.md
+++ b/docs/developer-guide/plugin/api-changelog.md
@@ -3,6 +3,12 @@ title: API 变更日志
 description: 记录每一个版本的插件 API 变更记录，方便开发者适配
 ---
 
+## 2.25.0
+
+### 表单定义 > `secret` 表单类型新增 `descriptionPreset` 参数
+
+在 2.25.0 中，`secret` 表单类型新增了 `descriptionPreset` 参数，用于在创建密钥时预填备注。详细文档可查阅：[表单定义#secret](../../developer-guide/form-schema.md#secret)。
+
 ## 2.23.0
 
 ### Spring Boot 依赖升级可能导致插件无法正常启动


### PR DESCRIPTION
## Summary

- Document the `descriptionPreset` option for the `secret` FormKit input.
- Add the plugin API changelog entry for Halo 2.25.0.

Related: halo-dev/halo#10027

## Validation

- `git diff --check`
- `pnpm lint`
- `pnpm build`
